### PR TITLE
Kuzzle first steps: removed duplicate Install Kuzzle section

### DIFF
--- a/src/guide/1/essentials/installing-kuzzle/index.md
+++ b/src/guide/1/essentials/installing-kuzzle/index.md
@@ -273,7 +273,7 @@ pm2 "<start|stop|restart>" kuzzlebackend
 ```
 
 <div class="alert alert-success">
-Now that Kuzzlee is up and running you can [install]({{ site_base_path }}guide/1/essentials/installing-console) the <strong>Kuzzle Admin Console</strong>.
+Now that Kuzzle is up and running you can <a href="/guide/1/essentials/installing-console">install</a> the <strong>Kuzzle Admin Console</strong>.
 </div>
 
 ### Troubleshooting

--- a/src/guide/1/essentials/introduction/index.md
+++ b/src/guide/1/essentials/introduction/index.md
@@ -12,7 +12,7 @@ Kuzzle is a ready-to-use, **open-source**, **on-premises** suite that allows you
 * **connect your apps** using our available SDKs and multiple protocols.
 * **manage your data** using the built-in pesistence engine.
 * **trigger real-time notifications** using our real-time engine.
-* **manage authentication** using Oauth2 and many other authentication strategies.
+* **manage authentication** using OAuth2 and many other authentication strategies.
 * **customize your backend** using the plugins engine and your own code.
 
 ## Connect your apps
@@ -22,14 +22,14 @@ Kuzzle ships with a set of open-source [SDKs]({{ site_base_path }}sdk-reference)
 - [Javascript](https://github.com/kuzzleio/sdk-javascript) (Node.js & Browsers)
 - [Android](https://github.com/kuzzleio/sdk-android)
 - [PHP](https://github.com/kuzzleio/sdk-php)
-- C (coming soon)
+- [and more]({{ site_base_path }}sdk-reference)...
 
 Additionally, Kuzzle supports a variety of communication protocols:
 
 - HTTP
 - Websocket
 - Socket.io
-- MQTT (via plugin)
+- MQTT
 
 You can interact directly with Kuzzle through its API, read the [Kuzzle API reference]({{ site_base_path }}api/1) for more information.
 

--- a/src/guide/1/getting-started/first-steps/index.md
+++ b/src/guide/1/getting-started/first-steps/index.md
@@ -7,80 +7,7 @@ order: 200
 
 # First Steps with Kuzzle
 
-In this tutorial you will learn how to install, run and use **Kuzzle** in just a few steps. We will walk you through creating an app that can **store** documents in Kuzzle and generate a **notification** for each new document.
-
-## Running Kuzzle
-
-This section learns you how to quickly get Kuzzle up and running using our installation script.
-
-Open a terminal and run the following command:
-
-```bash
-bash -c "$(curl https://get.kuzzle.io/)"
-```
-
-This command downloads and executes the installation script. The script checks the system for a set of prerequisites and installs missing ones, such as [Docker](https://www.docker.com/). When the installation is complete, it will automatically run Kuzzle.
-
-<div class="alert alert-info">
-There are also more <a href="{{ site_base_path }}guide/1/essentials/installing-kuzzle/">alternative ways</a> to install Kuzzle.
-</div>
-
-This command downloads, installs and runs Kuzzle.
-
-Use the `--no-run` option to prevent the script from running Kuzzle.
-
-Once the installation process is complete, you will see the following message:
-
-```bash
-# Kuzzle is now running
-```
-
-Your Kuzzle is now running! To test it, you can explore the main HTTP API by clicking this <a href="http://localhost:7512?pretty">link</a> or by using cURL on the command line:
-
-```bash
-curl "http://localhost:7512/?pretty"
-```
-
-If everything is working you should see a JSON document that contains a list of API endpoints.
-
-<div class="alert alert-success">
-Congratulations! You have completed the Kuzzle installation, it will now accept requests on <code>localhost:7512</code>:
-<ul>
-  <li>via <strong>HTTP</strong></li>
-  <li>via <strong>Websocket</strong></li>
-</ul>
-</div>
-
-<div class="alert alert-info">
-Having trouble?
-<ul>
-  <li>Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.</li>
-  <li>Try one of <a href="{{ site_base_path }}guide/1/essentials/installing-kuzzle/">these</a> alternative installation methods.</li>
-</ul>
-</div>
-
-
-#### Helper scripts for systemd
-
-If you want to run Kuzzle automatically at startup there are a few scripts that help you do this with systemd.
-
-If you want to run Kuzzle automatically at startup there are a few scripts in `$PWD/kuzzle/script/` that help you do this with systemd:
-
-* Run the `add-kuzzle-boot-systemd.sh` as root to add a service inside /etc/systemd/system that will start Kuzzle on boot.
-* Run the `remove-kuzzle-boot-systemd.sh` as root to remove the service so that Kuzzle won't start on boot.
-
-#### What now?
-
-Now that Kuzzle is up and running, you can start playing around with it:
-
-* install <a href="{{ site_base_path }}guide/1/essentials/installing-console">Kuzzle Admin Console</a>, a handy way to manage data and security in your Kuzzle installation
-* install a <a href="{{ site_base_path }}sdk-reference/">Kuzzle SDK</a> to power-up one of your projects
-* explore the <a href="{{ site_base_path }}api/1">Kuzzle API</a> documentation
-* install Kuzzle <a href="{{ site_base_path }}guide/1/essentials/installing-kuzzle/#manual-installation">without Docker</a>
-
-## Fun with SDKs
-
-It's time to play with the [Kuzzle SDK]({{ site_base_path }}sdk-reference). In this section, we will store a document and subscribe to notifications in Kuzzle using the Javascript SDK.
+It's time to play with the [Kuzzle JS SDK]({{ site_base_path }}sdk-reference). In this section, we will learn how to store a document and subscribe to notifications in Kuzzle using the Javascript SDK in a simple NodeJS client application.
 
 Before proceeding, please make sure your system has these programs installed:
 
@@ -94,6 +21,7 @@ Create your playground directory and install the [Javascript SDK]({{ site_base_p
 ```bash
 mkdir "kuzzle-playground"
 cd "kuzzle-playground"
+npm init
 npm install kuzzle-sdk
 ```
 


### PR DESCRIPTION
## What does this PR do?
In the First Steps section of the guide, removed the Install Kuzzle Section that was just the same content as Getting started page.

### How should this be manually tested?
Go to page https://deploy-preview-236--kuzzle-doc-v2.netlify.com/guide/1/getting-started/first-steps/ and validate the duplicated content from https://deploy-preview-236--kuzzle-doc-v2.netlify.com/guide/1/getting-started/running-kuzzle/ is no more present.

Also check the modified introduction is OK

### Other changes

* Fixed a MD links in a html section that wasn't converted to proper html link
* Fixed a few typo
* Some minor rewording
