### PR TITLE
Fix methods ordering in the document controller documentation

### DIFF
--- a/src/sdk-reference/cpp/1/document/delete/index.md
+++ b/src/sdk-reference/cpp/1/document/delete/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: delete
 description: Deletes a document from kuzzle
-order: 200
 ---
 
 # delete_

--- a/src/sdk-reference/cpp/1/document/deleteByQuery/index.md
+++ b/src/sdk-reference/cpp/1/document/deleteByQuery/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: deleteByQuery
 description: Delete documents matching query
-order: 200
 ---
 
 # deleteByQuery

--- a/src/sdk-reference/cpp/1/document/get/index.md
+++ b/src/sdk-reference/cpp/1/document/get/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: get
 description: Get a document from kuzzle
-order: 200
 ---
 
 # get

--- a/src/sdk-reference/cpp/1/document/mCreate/index.md
+++ b/src/sdk-reference/cpp/1/document/mCreate/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: mCreate
 description: Creates multiple documents in kuzzle
-order: 200
 ---
 
 # mCreate

--- a/src/sdk-reference/cpp/1/document/mCreateOrReplace/index.md
+++ b/src/sdk-reference/cpp/1/document/mCreateOrReplace/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: mCreateOrReplace
 description: Create or replace documents in kuzzle
-order: 200
 ---
 
 # mCreateOrReplace

--- a/src/sdk-reference/cpp/1/document/mDelete/index.md
+++ b/src/sdk-reference/cpp/1/document/mDelete/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: mDelete
 description: Delete a document
-order: 200
 ---
 
 # mDelete

--- a/src/sdk-reference/cpp/1/document/mGet/index.md
+++ b/src/sdk-reference/cpp/1/document/mGet/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: mGet
 description: Get multiple documents from kuzzle
-order: 200
 ---
 
 # mGet

--- a/src/sdk-reference/cpp/1/document/mReplace/index.md
+++ b/src/sdk-reference/cpp/1/document/mReplace/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: mReplace
 description: Replace documents
-order: 200
 ---
 
 # mReplace

--- a/src/sdk-reference/cpp/1/document/mUpdate/index.md
+++ b/src/sdk-reference/cpp/1/document/mUpdate/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: mUpdate
 description: Update documents
-order: 200
 ---
 
 # mUpdate

--- a/src/sdk-reference/cpp/1/document/replace/index.md
+++ b/src/sdk-reference/cpp/1/document/replace/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: replace
 description: Replace a document
-order: 200
 ---
 
 # replace

--- a/src/sdk-reference/cpp/1/document/search/index.md
+++ b/src/sdk-reference/cpp/1/document/search/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: search
 description: Search documents
-order: 200
 ---
 
 # search

--- a/src/sdk-reference/cpp/1/document/update/index.md
+++ b/src/sdk-reference/cpp/1/document/update/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: update
 description: Update a document
-order: 200
 ---
 
 # update

--- a/src/sdk-reference/cpp/1/document/validate/index.md
+++ b/src/sdk-reference/cpp/1/document/validate/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: validate
 description: Validate a document
-order: 200
 ---
 
 # validate


### PR DESCRIPTION
# Description

This PR fixes the ordering of the C++ SDK functions for the `document` controller:

![screenshot from 2019-02-28 12-08-11](https://user-images.githubusercontent.com/12997967/53562394-8ddd6f80-3b51-11e9-9d0b-f5054e0becd8.png)

