### PR TITLE
[C++ SDK] Use the kuzzleio namespace

### DIFF
--- a/src/sdk-reference/cpp/1/getting-started/snippets/connect.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/connect.cpp
@@ -4,36 +4,37 @@
 #include "kuzzle.hpp"
 
 int main(int argc, char * argv[]) {
-    // Instanciate a Kuzzle client
-    // with a WebSocket connection.
-    // Replace "kuzzle" with
-    // your Kuzzle hostname like "localhost"
-    Kuzzle *kuzzle = new kuzzleio::Kuzzle(new kuzzleio::WebSocket("kuzzle"));
+  // Instantiate a Kuzzle client with a WebSocket connection.
+  // Replace "kuzzle" with your actual Kuzzle hostname (e.g. "localhost")
+  kuzzleio::WebSocket * ws = new kuzzleio::WebSocket("kuzzle");
+  kuzzleio::Kuzzle *kuzzle = new kuzzleio::Kuzzle(ws);
 
-    try {
-        // Connects to the server.
-        kuzzle->connect();
-        std::cout << "Connected!" << std::endl;
-    }
-    catch(KuzzleException &e) {
-        std::cerr << e.what() << std::endl;
-        exit(1);
-    }
+  try {
+    // Connect to the server.
+    kuzzle->connect();
+    std::cout << "Connected!" << std::endl;
+  }
+  catch(kuzzleio::KuzzleException &e) {
+    std::cerr << e.what() << std::endl;
+    exit(1);
+  }
 
-    try {
-        // Get server current date as UNIX timestamp.
-        std::cout << "Server current timestamp: "
-                  << kuzzle->server->now()
-                  << std::endl;
-    }
-    catch(KuzzleException &e) {
-        std::cerr << e.what() << std::endl;
-        kuzzle->disconnect();
-        exit(1);
-    }
-
-    // Disconnects the SDK.
+  try {
+    // Get the server current date as a UNIX timestamp.
+    std::cout << "Server current timestamp: "
+    << kuzzle->server->now()
+    << std::endl;
+  }
+  catch(kuzzleio::KuzzleException &e) {
+    std::cerr << e.what() << std::endl;
     kuzzle->disconnect();
+    exit(1);
+  }
 
-    return 0;
+  // Disconnect and free resources
+  kuzzle->disconnect();
+  delete kuzzle;
+  delete ws;
+
+  return 0;
 }

--- a/src/sdk-reference/cpp/1/getting-started/snippets/document.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/document.cpp
@@ -1,51 +1,52 @@
 #include <iostream>
-
 #include "kuzzle.hpp"
 #include "websocket.hpp"
 
-#define K_INDEX_NAME "nyc-open-data"
-#define K_COLLECTION_NAME "yellow-taxi"
-
-
 int main(int argc, char * argv[]) {
-    std::string res;
-    // Instanciate a Kuzzle client
-    // with a WebSocket connection.
-    // Replace "kuzzle" with
-    // your Kuzzle hostname like "localhost"
-    Kuzzle *kuzzle = new kuzzleio::Kuzzle(new kuzzleio::WebSocket("kuzzle"));
-    try {
-        // Connects to the server.
-        kuzzle->connect();
-        std::cout << "Connected!" << std::endl;
-    }
-    catch(KuzzleException &e) {
-        std::cerr << e.what() << std::endl;
-        exit(1);
-    }
+  // Instantiate a Kuzzle client with a WebSocket connection.
+  // Replace "kuzzle" with your actual Kuzzle hostname (e.g. "localhost")
+  kuzzleio::WebSocket *ws = new kuzzleio::WebSocket("kuzzle");
+  kuzzleio::Kuzzle *kuzzle = new kuzzleio::Kuzzle(ws);
 
-    // New document content
-    std::string document = R"(
-      {
-        "name": "Sirkis",
-        "birthday": "1959-06-22",
-        "license": "B"
-      }
-    )";
+  try {
+    // Connect to the server.
+    kuzzle->connect();
+    std::cout << "Connected!" << std::endl;
+  }
+  catch(kuzzleio::KuzzleException &e) {
+      std::cerr << e.what() << std::endl;
+      exit(1);
+  }
 
-    try {
-        // Stores the document in the "yellow-taxi" collection.
-        res = kuzzle->document->create(K_INDEX_NAME, K_COLLECTION_NAME, "some-id", document);
-        std::cout << "Document created successfuly: " << res << std::endl;
+  // New document content
+  std::string document = R"(
+    {
+      "name": "Sirkis",
+      "birthday": "1959-06-22",
+      "license": "B"
     }
-    catch(KuzzleException &e) {
-        std::cerr << e.what() << std::endl;
-        kuzzle->disconnect();
-        exit(1);
-    }
+  )";
 
-    // Disconnects the SDK.
-    kuzzle->disconnect();
+  try {
+    // Store the document in the "yellow-taxi" collection, itself in the
+    // "nyc-open-data" data index
+    std::string response = kuzzle->document->create(
+        "nyc-open-data",
+        "yellow-taxi",
+        "document-id",
+        document);
+    std::cout << "Document created successfully: " << response << std::endl;
+  }
+  catch(kuzzleio::KuzzleException &e) {
+      std::cerr << e.what() << std::endl;
+      exit(1);
+  }
 
-    return 0;
+  // Disconnect and free allocated resources
+  kuzzle->disconnect();
+
+  delete kuzzle;
+  delete ws;
+
+  return 0;
 }

--- a/src/sdk-reference/cpp/1/getting-started/snippets/init.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/init.cpp
@@ -1,47 +1,38 @@
 #include <iostream>
-
 #include "kuzzle.hpp"
 #include "websocket.hpp"
 
-#define K_INDEX_NAME "nyc-open-data"
-#define K_COLLECTION_NAME "yellow-taxi"
-
-
 int main(int argc, char * argv[]) {
-    // Instanciate a Kuzzle client
-    // with a WebSocket connection.
-    // Replace "kuzzle" with
-    // your Kuzzle hostname like "localhost"
-    Kuzzle *kuzzle = new kuzzleio::Kuzzle(new kuzzleio::WebSocket("kuzzle"));
+  // Instantiate a Kuzzle client with a WebSocket connection.
+  // Replace "kuzzle" with your actual Kuzzle hostname (e.g. "localhost")
+  kuzzleio::WebSocket *ws = new kuzzleio::WebSocket("kuzzle");
+  kuzzleio::Kuzzle *kuzzle = new kuzzleio::Kuzzle(ws);
 
-    try {
-        // Connects to the server.
-        kuzzle->connect();
-        std::cout << "Connected!" << std::endl;
+  try {
+    // Connect to the server.
+    kuzzle->connect();
+    std::cout << "Connected!" << std::endl;
 
-        // Freshly installed Kuzzle servers are empty: we need to create
-        // a new index.
-        kuzzle->index->create(K_INDEX_NAME);
-        std::cout << "Index "
-                  << K_INDEX_NAME
-                  << " created!"
-                  << std::endl;
+    // Freshly installed Kuzzle servers are empty: we first need to create
+    // a data index. The one used in this example is named "nyc-open-data"
+    kuzzle->index->create("nyc-open-data");
+    std::cout << "Index nyc-open-data created!" << std::endl;
 
-        // Creates a collection
-        kuzzle->collection->create(K_INDEX_NAME, K_COLLECTION_NAME);
-        std::cout << "Collection "
-                  << K_COLLECTION_NAME
-                  << " created!"
-                  << std::endl;
-    }
-    catch(KuzzleException e) {
-        std::cerr << e.what() << std::endl;
-        exit(1);
-    }
+    // Create a data collection named "yellow-taxi" in our newly created index
+    kuzzle->collection->create("nyc-open-data", "yellow-taxi");
+    std::cout << "Collection yellow-taxi created!" << std::endl;
+  }
+  catch(kuzzleio::KuzzleException e) {
+    std::cerr << e.what() << std::endl;
+    exit(1);
+  }
 
-    // Disconnects the SDK
-    kuzzle->disconnect();
+  // Disconnect and free allocated resources
+  kuzzle->disconnect();
 
-    return 0;
+  delete kuzzle;
+  delete ws;
+
+  return 0;
 }
 

--- a/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
@@ -30,7 +30,7 @@ int main(int argc, char * argv[]) {
 
   try {
     // Subscribe to notifications for drivers having a "B" driver license.
-    const char *filters = R"(
+   std::string filters = R"(
       {
          "equals": {
            "license": "B"

--- a/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
@@ -24,7 +24,7 @@ int main(int argc, char * argv[]) {
   // received
   kuzzleio::NotificationListener listener =
     [](const std::shared_ptr<kuzzleio::notification_result> &notification) {
-      const char *id = notification->result->id;
+      std::string id = notification->result->id;
       std::cout << "New created document notification: " << id << std::endl;
     };
 

--- a/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
@@ -1,72 +1,79 @@
 #include <unistd.h>
-
 #include <iostream>
-
+#include <memory>
 #include "websocket.hpp"
 #include "kuzzle.hpp"
 
-#define K_INDEX_NAME "nyc-open-data"
-#define K_COLLECTION_NAME "yellow-taxi"
-
 int main(int argc, char * argv[]) {
-    // Instanciate a Kuzzle client
-    // with a WebSocket connection.
-    // Replace "kuzzle" with
-    // your Kuzzle hostname like "localhost"
-    Kuzzle *kuzzle = new kuzzleio::Kuzzle(new kuzzleio::WebSocket("kuzzle"));
+  // Instantiate a Kuzzle client with a WebSocket connection.
+  // Replace "kuzzle" with your actual Kuzzle hostname (e.g. "localhost")
+  kuzzleio::WebSocket *ws = new kuzzleio::WebSocket("kuzzle");
+  kuzzleio::Kuzzle *kuzzle = new kuzzleio::Kuzzle(ws);
 
-    try {
-        // Connects to the server.
-        kuzzle->connect();
-        std::cout << "Connected!" << std::endl;
-    }
-    catch(KuzzleException &e) {
-        std::cerr << e.what() << std::endl;
-        exit(1);
-    }
+  try {
+    // Connect to the server.
+    kuzzle->connect();
+    std::cout << "Connected!" << std::endl;
+  }
+  catch(kuzzleio::KuzzleException &e) {
+    std::cerr << e.what() << std::endl;
+    exit(1);
+  }
 
-    // Starts an async listener
-    kuzzleio::NotificationListener listener =
-      [](const std::shared_ptr<kuzzleio::notification_result> &notification) {
-        const char *id = notification->result->id;
-        std::cout << "New created document notification: " << id << std::endl;
-      };
+  // Create a lambda that will be invoked for each real-time notification
+  // received
+  kuzzleio::NotificationListener listener =
+    [](const std::shared_ptr<kuzzleio::notification_result> &notification) {
+      const char *id = notification->result->id;
+      std::cout << "New created document notification: " << id << std::endl;
+    };
 
-    try {
-      // Subscribes to notifications for drivers having a "B" driver license.
-      const char *filters = R"(
-        {
-           "equals": {
-             "license": "B"
-           }
-        }
-      )";
+  try {
+    // Subscribe to notifications for drivers having a "B" driver license.
+    const char *filters = R"(
+      {
+         "equals": {
+           "license": "B"
+         }
+      }
+    )";
 
-      // Sends the subscription
-      kuzzle->realtime->subscribe(K_INDEX_NAME, K_COLLECTION_NAME, filters, &listener);
-      std::cout << "Successfully subscribed!" << std::endl;
+    kuzzle->realtime->subscribe(
+        "nyc-open-data",
+        "yellow-taxi",
+        filters,
+        &listener);
+    std::cout << "Successfully subscribed!" << std::endl;
 
-      // Writes a new document. This triggers a notification
-      // sent to our subscription.
-      const char *document = R"(
-        {
-          "name": "John",
-          "birthday": "1995-11-27",
-          "license": "B"
-        }
-      )";
+    // Write a new document. This triggers a notification
+    // sent to our subscription.
+    const char *document = R"(
+      {
+        "name": "John",
+        "birthday": "1995-11-27",
+        "license": "B"
+      }
+    )";
 
-      kuzzle->document->create(K_INDEX_NAME, K_COLLECTION_NAME, "some-id", document);
-      // Wait for notification
-      sleep(2);
-    } catch (kuzzleio::KuzzleException &e) {
-      std::cerr << e.what() << std::endl;
-      kuzzle->disconnect();
-      exit(1);
-    }
-
-    // Disconnects the SDK.
+    kuzzle->document->create(
+        "nyc-open-data",
+        "yellow-taxi",
+        "some-id",
+        document);
+  } catch (kuzzleio::KuzzleException &e) {
+    std::cerr << e.what() << std::endl;
     kuzzle->disconnect();
+    exit(1);
+  }
 
-    return 0;
+  // Wait for the notification to be received
+  sleep(2);
+
+  // Disconnect and free allocated resources
+  kuzzle->disconnect();
+
+  delete kuzzle;
+  delete ws;
+
+  return 0;
 }

--- a/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
@@ -1,4 +1,3 @@
-#include <unistd.h>
 #include <iostream>
 #include <memory>
 #include "websocket.hpp"
@@ -23,14 +22,21 @@ int main(int argc, char * argv[]) {
   // Create a lambda that will be invoked for each real-time notification
   // received
   kuzzleio::NotificationListener listener =
-    [](const std::shared_ptr<kuzzleio::notification_result> &notification) {
+    [&](const std::shared_ptr<kuzzleio::notification_result> &notification) {
       std::string id = notification->result->id;
       std::cout << "New created document notification: " << id << std::endl;
+
+      // Disconnect and free allocated resources, allowing the
+      // program to exit at the first notification received
+      kuzzle->disconnect();
+
+      delete kuzzle;
+      delete ws;
     };
 
   try {
     // Subscribe to notifications for drivers having a "B" driver license.
-   std::string filters = R"(
+    std::string filters = R"(
       {
          "equals": {
            "license": "B"
@@ -65,15 +71,6 @@ int main(int argc, char * argv[]) {
     kuzzle->disconnect();
     exit(1);
   }
-
-  // Wait for the notification to be received
-  sleep(2);
-
-  // Disconnect and free allocated resources
-  kuzzle->disconnect();
-
-  delete kuzzle;
-  delete ws;
 
   return 0;
 }

--- a/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
+++ b/src/sdk-reference/cpp/1/getting-started/snippets/realtime.cpp
@@ -47,7 +47,7 @@ int main(int argc, char * argv[]) {
 
     // Write a new document. This triggers a notification
     // sent to our subscription.
-    const char *document = R"(
+    std::string document = R"(
       {
         "name": "John",
         "birthday": "1995-11-27",

--- a/src/sdk-reference/cpp/1/kuzzle/add-listener/snippets/add-listener.cpp
+++ b/src/sdk-reference/cpp/1/kuzzle/add-listener/snippets/add-listener.cpp
@@ -1,14 +1,20 @@
-kuzzleio::SharedEventListener listener = std::make_shared<EventListener>(
-  [](const std::string &payload) {
-    std::cout << payload << std::endl;
-  });
-kuzzleio::SharedEventListener other_listener = std::make_shared<EventListener>(
-  [](const std::string &payload) {
-    std::cerr << payload << std::endl;
-  });
+{
+  using kuzzleio::SharedEventListener;
+  using kuzzleio::EventListener;
 
-kuzzle
-  ->addListener(KUZZLE_EVENT_CONNECTED, listener)
-  ->addListener(KUZZLE_EVENT_CONNECTED, other_listener);
+  SharedEventListener listener = std::make_shared<EventListener>(
+    [](const std::string &payload) {
+      std::cout << payload << std::endl;
+    });
+
+  SharedEventListener other_listener = std::make_shared<EventListener>(
+    [](const std::string &payload) {
+      std::cerr << payload << std::endl;
+    });
+
+  kuzzle
+    ->addListener(kuzzleio::KUZZLE_EVENT_CONNECTED, listener)
+    ->addListener(kuzzleio::KUZZLE_EVENT_CONNECTED, other_listener);
+}
 
 std::cout << "Listener successfully added" << std::endl;

--- a/src/sdk-reference/cpp/1/websocket/getters/index.md
+++ b/src/sdk-reference/cpp/1/websocket/getters/index.md
@@ -7,51 +7,21 @@ order: 100
 
 # WebSocket class getters
 
-## isAutoReconnect
-
-Returns the auto-reconnection flag value.
-
-### Signature
-
-```cpp
-bool isAutoReconnect()
-```
-
-## isAutoResubscribe
-
-Returns the auto-resubscribe flag value.
-
-### Signature
-
-```cpp
-bool isAutoResubscribe()
-```
-
 ## getPort
 
 Returns the port number used by the protocol instance.
 
-### Signature
+### Arguments
 
 ```cpp
 unsigned int getPort()
 ```
 
-## getReconnectionDelay
-
-Returns the reconnection delay used by the protocol instance.
-
-### Signature
-
-```cpp
-uint64_t getReconnectionDelay()
-```
-
 ## isSslConnection
 
-Returns a boolean indicating is the protocol instance is using SSL or not.
+Returns a boolean indicating if the protocol instance is using SSL or not.
 
-### Signature
+### Arguments
 
 ```cpp
 bool isSslConnection()

--- a/src/sdk-reference/cpp/1/websocket/getters/snippets/getters.cpp
+++ b/src/sdk-reference/cpp/1/websocket/getters/snippets/getters.cpp
@@ -1,11 +1,5 @@
-kuzzleio::WebSocket *protocol = new WebSocket("kuzzle");
-
-bool auto_reconnects = protocol->isAutoReconnect();
-
-bool auto_resubscribes = protocol->isAutoResubscribe();
+kuzzleio::WebSocket *protocol = new kuzzleio::WebSocket("kuzzle");
 
 unsigned int port = protocol->getPort();
-
-uint64_t reconnection_delay = protocol->getReconnectionDelay();
 
 bool ssl_connection = protocol->isSslConnection();

--- a/test/templates/catch.tpl.cpp
+++ b/test/templates/catch.tpl.cpp
@@ -24,5 +24,11 @@ int main() {
   } catch (kuzzleio::KuzzleException &e) {
     std::cout << "Success" << std::endl;
   }
+
+  kuzzle->disconnect();
+
+  delete kuzzle;
+  delete ws;
+
   return 0;
 }

--- a/test/templates/default.tpl.cpp
+++ b/test/templates/default.tpl.cpp
@@ -22,5 +22,11 @@ int main() {
   }
 
   [snippet-code]
+
+  kuzzle->disconnect();
+
+  delete kuzzle;
+  delete ws;
+
   return 0;
 }

--- a/test/templates/realtime.tpl.cpp
+++ b/test/templates/realtime.tpl.cpp
@@ -46,5 +46,10 @@ int main() {
   std::cout.rdbuf(cout_original);
   std::cout << cout_copy.str();
 
+  kuzzle->disconnect();
+
+  delete kuzzle;
+  delete ws;
+
   return 0;
 }

--- a/test/templates/without-connect.tpl.cpp
+++ b/test/templates/without-connect.tpl.cpp
@@ -13,5 +13,8 @@ int main() {
 
   [snippet-code]
 
+  delete kuzzle;
+  delete ws;
+
   return 0;
 }


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-cpp/pull/70

Please restart the CI once the C++ SDK is updated.

# Description

Add the missing `kuzzleio::` namespace, required by the now fixed C++ SDK (see https://github.com/kuzzleio/sdk-cpp/pull/70)

# Other changes

* C++ Getting Started guides:
  * fix typos in comments
  * use our standard formatting convention (2 spaces, 80 chars columns, ...)
  * fix the memleaked WebSocket pointer
  * add missing `disconnect` call, and missing pointer deletions
  * remove`#define` pragmas for data index and collection, as they made the code examples harder to follow, at least from my point of view
* add missing `disconnect` call, and missing pointer deletions in C++ test templates
