### PR TITLE
[install guide] Add a note about the max open files ulimit value

### DIFF
--- a/src/guide/1/essentials/installing-kuzzle/index.md
+++ b/src/guide/1/essentials/installing-kuzzle/index.md
@@ -140,11 +140,12 @@ The following operating systems are actively supported (64-bit versions only):
 
 * [Elasticsearch](https://www.elastic.co/products/elasticsearch) version 5.x
 * [Redis](http://redis.io/) version 3.x
-* [Node.js](https://nodejs.org/en/download/package-manager/) version 6.x or higher.
-* [NPM](https://www.npmjs.com/) version 3 or higher.
-* [Python](https://www.python.org/) version 2.7 preferred.
-* [GDB](https://www.gnu.org/software/gdb/) version 7.7 or higher.
-* a C++11 compatible compiler.
+* [Node.js](https://nodejs.org/en/download/package-manager/) version 6.x or higher
+* [NPM](https://www.npmjs.com/) version 3 or higher
+* [Python](https://www.python.org/) version 2.7 preferred
+* [GDB](https://www.gnu.org/software/gdb/) version 7.7 or higher
+* a C++11 compatible compiler
+* it's strongly advised that the system value for the maximum number of opened files (`ulimit -n` on most Unix systems) is set to a high value (i.e. 65535 is a good min. value)
 
 <div class="alert alert-info">
  The last three prerequisites can be fulfilled on Debian-based systems by installing packages : <code>build-essential</code>, <code>gdb</code> and <code>python</code>.


### PR DESCRIPTION
# Description

Add a note in the manual installation section, instructing users to check their `ulimit -n` value on the server hosting Kuzzle instances