### PR TITLE
[API] new auth:refreshToken API route documentation

### DIFF
--- a/src/api/1/controller-auth/refresh-token/index.md
+++ b/src/api/1/controller-auth/refresh-token/index.md
@@ -1,0 +1,73 @@
+---
+layout: full.html.hbs
+title: refreshToken
+---
+
+# refreshToken
+
+{{{since "1.7.0"}}}
+
+Refreshes an authentication token:
+
+* a valid, non-expired authentication must be provided
+* the provided authentication token is revoked
+* a new authentication token is generated and returned
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_refreshToken[?expiresIn=<expiresIn>]
+Method: POST  
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "auth",
+  "action": "refreshToken",
+  "expiresIn": "<expiresIn>"
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `expiresIn`: set the expiration duration (default: depends on [Kuzzle configuration file]({{ site_base_path }}guide/1/essentials/configuration/))
+  * if a raw number is provided (not enclosed between quotes), then the expiration delay is in milliseconds. Example: `86400000`
+  * if this value is a string, then its content is parsed by the [ms](https://www.npmjs.com/package/ms) library. Examples: `"6d"`, `"10h"`
+
+---
+
+## Response
+
+The result contains the following properties:
+
+* `_id`: user's [kuid]({{ site_base_path }}guide/1/kuzzle-depth/authentication#the-kuzzle-user-identifier) 
+* `jwt`: encrypted JSON Web Token, that must then be sent in the [requests headers]({{ site_base_path }}api/1/essentials/query-syntax/#http-default) or in the [query]({{ site_base_path }}api/1/essentials/query-syntax/#other-protocols-default)
+* `expiresAt`: new token expiration date, in Epoch-millis (UTC)
+* `ttl`: new token time to live, in milliseconds
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "controller": "auth",
+  "action": "refreshToken",
+  "requestId": "<unique request identifier>",
+  "volatile": {},
+  "result": {
+    "_id": "<kuid>",
+    "jwt": "<JWT encrypted token>",
+    "expiresAt": 1321085955000,
+    "ttl": 360000
+  }
+}
+```


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/kuzzle/pull/1265

# Description

Document the new `auth:refreshToken` API route

# How to review

Go to the `api/1/controller-auth/refresh-token/` URL in the netlify preview