### PR TITLE
[debug] Print standard output on an assertion error

### DIFF
--- a/test/lib/helpers/logger.js
+++ b/test/lib/helpers/logger.js
@@ -82,6 +82,9 @@ class Logger {
         console.log(red('        CODE    :'), result.code);
         console.log(red('        FILE    :'), result.file);
         if (result.code === 'ERR_ASSERTION') {
+          if (result.output.length > 0) {
+            console.log(red('        OUTPUT  :'), result.output);
+          }
           console.log(red('        EXPECTED:'), result.expected || snippet.expected);
           console.log(red('        GOT     :'), result.actual);
         } else if (result.code === 'ERR_ORDER') {

--- a/test/lib/runners/baseRunner.js
+++ b/test/lib/runners/baseRunner.js
@@ -45,7 +45,8 @@ module.exports = class BaseRunner {
         if (error) {
           const res = {
             code: 'ERR_ASSERTION',
-            actual: error.actual || error
+            actual: error.actual || error,
+            output: stdout
           };
 
           reject(new TestResult(res));


### PR DESCRIPTION
# Description

This makes the snippet tests print the standard output instead of hiding it when an error occurs, which can be handy for lazy and quick debug tests, such as printing a few information before a known crash occurs.

(or, the other way around: it's infuriating and it's a loss of time figuring out why a console.log or a std::cout doesn't print anything :expressionless: )