### PR TITLE
auth:checkToken: remove an erroneous and confusing precision

### DIFF
--- a/.ci/comment.html
+++ b/.ci/comment.html
@@ -9,7 +9,7 @@
       <td align="center">
         <a href="https://dl.kuzzle.io/reports/{{.prId}}/js/6/report.html"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/javascript.png"
+        "https://docs.kuzzle.io/assets/images/logos/javascript.png"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v6</em></td>
@@ -29,7 +29,7 @@
       <td align="center">
         <a href="https://dl.kuzzle.io/reports/{{.prId}}/js/5/report.html"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/javascript.png"
+        "https://docs.kuzzle.io/assets/images/logos/javascript.png"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v5</em></td>
@@ -49,7 +49,7 @@
       <td align="center">
         <a href="https://dl.kuzzle.io/reports/{{.prId}}/go/1/report.html"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/go.png"
+        "https://docs.kuzzle.io/assets/images/logos/go.png"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v1</em></td>
@@ -69,7 +69,7 @@
       <td align="center">
         <a href="https://dl.kuzzle.io/reports/{{.prId}}/java/1/report.html"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/java.png"
+        "https://docs.kuzzle.io/assets/images/logos/java.png"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v1</em></td>
@@ -89,7 +89,7 @@
       <td align="center">
         <a href="https://dl.kuzzle.io/reports/{{.prId}}/cpp/1/report.html"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/cpp.png"
+        "https://docs.kuzzle.io/assets/images/logos/cpp.png"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v1</em></td>
@@ -109,7 +109,7 @@
       <td align="center">
         <a href="https://dl.kuzzle.io/reports/{{.prId}}/csharp/1/report.html"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/csharp.png"
+        "https://docs.kuzzle.io/assets/images/logos/csharp.png"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v1</em></td>

--- a/.ci/comment_pr.sh
+++ b/.ci/comment_pr.sh
@@ -12,7 +12,7 @@ echo '{"prId": "'"$TRAVIS_PULL_REQUEST"'", "cppv1": "'"$cppv1"'", "javav1": "'"$
 docker run --rm -it -v "$(pwd)":/mnt alexandrebouthinon/kuttlefish kuttlefish \
         -template /mnt/.ci/comment.html \
         -data /mnt/.ci/data.json \
-        -repo documentation-v2 \
+        -repo documentation \
         -owner kuzzleio \
         -token $GH_TOKEN\
         -id $TRAVIS_PULL_REQUEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
 
       script:
         - npm install
+        - npm run lint
         - npm run build
 
       after_script:
@@ -64,7 +65,7 @@ jobs:
         - "8"
 
       before_install:
-        - docker pull kuzzleio/documentation-v2:js
+        - docker pull kuzzleio/documentation:js
         - sysctl -w vm.max_map_count=262144
 
       script:
@@ -75,8 +76,8 @@ jobs:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
             mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/js/5/ --recursive --exclude "*.gitkeep"
-            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
-            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
+            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
+            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
           fi;
 
@@ -88,7 +89,7 @@ jobs:
         - "8"
 
       before_install:
-        - docker pull kuzzleio/documentation-v2:js
+        - docker pull kuzzleio/documentation:js
         - sysctl -w vm.max_map_count=262144
 
       script:
@@ -99,8 +100,8 @@ jobs:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
             mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/js/6/ --recursive --exclude "*.gitkeep"
-            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
-            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
+            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
+            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
           fi;
 
@@ -112,7 +113,7 @@ jobs:
         - "8"
 
       before_install:
-        - docker pull kuzzleio/documentation-v2:go
+        - docker pull kuzzleio/documentation:go
         - sysctl -w vm.max_map_count=262144
 
       script:
@@ -123,8 +124,8 @@ jobs:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
             mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/go/1/ --recursive --exclude "*.gitkeep"
-            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
-            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
+            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
+            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
           fi;
 
@@ -136,7 +137,7 @@ jobs:
         - "8"
 
       before_install:
-        - docker pull kuzzleio/documentation-v2:java
+        - docker pull kuzzleio/documentation:java
         - sysctl -w vm.max_map_count=262144
 
       script:
@@ -147,8 +148,8 @@ jobs:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
             mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/java/1/ --recursive --exclude "*.gitkeep"
-            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
-            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
+            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
+            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
           fi;
 
@@ -160,7 +161,7 @@ jobs:
         - "8"
 
       before_install:
-        - docker pull kuzzleio/documentation-v2:cpp
+        - docker pull kuzzleio/documentation:cpp
         - sysctl -w vm.max_map_count=262144
 
       script:
@@ -171,8 +172,8 @@ jobs:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
             mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/cpp/1/ --recursive --exclude "*.gitkeep"
-            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
-            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
+            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
+            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
           fi;
 
@@ -184,7 +185,7 @@ jobs:
         - "8"
 
       before_install:
-        - docker pull kuzzleio/documentation-v2:csharp
+        - docker pull kuzzleio/documentation:csharp
         - sysctl -w vm.max_map_count=262144
 
       script:
@@ -195,8 +196,8 @@ jobs:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
             mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/csharp/1/ --recursive --exclude "*.gitkeep"
-            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
-            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
+            cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
+            cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
           fi;
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Documentation-V2
+# Documentation
 
 ## Usage
 

--- a/docker/js
+++ b/docker/js
@@ -1,4 +1,4 @@
-FROM kuzzleio/puppeteer-light:latest
+FROM buildkite/puppeteer:latest
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
   curl \
@@ -10,8 +10,7 @@ RUN mkdir /nodejs && curl http://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-x64.ta
 
 ENV PATH $PATH:/nodejs/bin
 
-
-RUN npm i -g eslint eslint-plugin-import@latest eslint-plugin-node@latest eslint-plugin-promise@latest eslint-plugin-standard@latest 
+RUN npm i -g eslint eslint-plugin-import@latest eslint-plugin-node@latest eslint-plugin-promise@latest eslint-plugin-standard@latest
 RUN npm i -g puppeteer mqtt webpack@4.29.5 webpack-cli@3.2.3 html-webpack-plugin@3.2.0 --unsafe-perm=true
 
 WORKDIR /app

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ const metalsmith = _metalsmith(__dirname)
     site_title: 'Kuzzle documentation',
     site_url: options.build.host,
     site_base_path: options.build.path,
-    gh_repo: process.env.TRAVIS_REPO_SLUG || 'kuzzleio/documentation-V2',
+    gh_repo: process.env.TRAVIS_REPO_SLUG || 'kuzzleio/documentation',
     gh_branch: process.env.TRAVIS_BRANCH || 'master',
     algolia_projectId: options.algolia.projectId,
     algolia_publicKey: options.algolia.publicKey,

--- a/plugins/anchors.js
+++ b/plugins/anchors.js
@@ -7,7 +7,7 @@ module.exports = {
       $ = cheerio.load(data.contents.toString());
 
     $('h1, h2').each((i, el) => {
-      id = `${$(el)
+      const id = `${$(el)
         .text()
         .replace(/&.*?/g, '')
         .replace(/\s+/g, '-')

--- a/run-snippet-tests.sh
+++ b/run-snippet-tests.sh
@@ -65,19 +65,19 @@ echo "SDK: $SDK version $SDK_VERSION"
 
 case $SDK in
   js)
-    docker run -it --name runner_js --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation-v2:js $SDK $SDK_VERSION $TESTS_PATH
+    docker run -it --name runner_js --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation:js $SDK $SDK_VERSION $TESTS_PATH
   ;;
   go)
-    docker run -it --name runner_go --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app -v "$(pwd)"/test/bin:/go/src/github.com/kuzzleio/go-test kuzzleio/documentation-v2:go $SDK $SDK_VERSION $TESTS_PATH
+    docker run -it --name runner_go --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app -v "$(pwd)"/test/bin:/go/src/github.com/kuzzleio/go-test kuzzleio/documentation:go $SDK $SDK_VERSION $TESTS_PATH
   ;;
   cpp)
-    docker run -it --name runner_cpp --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation-v2:cpp $SDK $SDK_VERSION $TESTS_PATH
+    docker run -it --name runner_cpp --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation:cpp $SDK $SDK_VERSION $TESTS_PATH
   ;;
   java)
-    docker run -it --name runner_java --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation-v2:java $SDK $SDK_VERSION $TESTS_PATH
+    docker run -it --name runner_java --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation:java $SDK $SDK_VERSION $TESTS_PATH
   ;;
   csharp)
-    docker run -it --name runner_csharp --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation-v2:csharp $SDK $SDK_VERSION $TESTS_PATH
+    docker run -it --name runner_csharp --rm -e DEV_MODE="$DEV_MODE" -e SDK_VERSION="$SDK_VERSION" -e LANGUAGE="$SDK" --network ci_default --link kuzzle -v "$(pwd)":/app kuzzleio/documentation:csharp $SDK $SDK_VERSION $TESTS_PATH
   ;;
   *)
     echo "$SDK is not a valid sdk"

--- a/src/api/1/controller-auth/check-token/index.md
+++ b/src/api/1/controller-auth/check-token/index.md
@@ -7,9 +7,7 @@ title: checkToken
 
 {{{since "1.0.0"}}}
 
-Checks a JWT validity.
-
-This API route does not require the caller to be logged in.
+Checks the validity of an authentication token.
 
 ---
 
@@ -23,7 +21,7 @@ Method: POST
 Body:  
 ```
 
-```js
+```json
 {
   "token": "<the JWT to check>"
 }
@@ -31,7 +29,7 @@ Body:
 
 ### Other protocols
 
-```js
+```json
 {
   "controller": "auth",
   "action": "checkToken",
@@ -45,7 +43,7 @@ Body:
 
 ## Body properties
 
-* `token`: the JWT to be tested
+* `token`: the authentication token to be tested
 
 ---
 
@@ -59,7 +57,7 @@ The returned result contains the following properties:
 
 Example:
 
-```js
+```json
 {
   "status": 200,
   "error": null,

--- a/src/sdk-reference/js/6/auth/check-token/index.md
+++ b/src/sdk-reference/js/6/auth/check-token/index.md
@@ -8,8 +8,6 @@ description: Checks a JWT's validity.
 
 Checks a token validity.
 
-This API route does not require the caller to be logged in.
-
 <br/>
 
 ```javascript


### PR DESCRIPTION
# Description

In our `auth:checkToken` documentation there is the following sentence: `This API route does not require the caller to be logged in.`

After thinking hard about it I _think_ I understand what it means: "you don't need to have an authentication token active to verify a token". Which should be obvious, since we require the token to be checked to be set in the body part of the request.

Moreover, even with a more explicit comment, that would still be confusing, because Kuzzle doesn't give any special treatment to this API route: administrators can remove rights to it to the anonymous role, meaning that you cannot use it without being logged in (or at all). That may sounds weird, but that's how it is.

# Other changes

- The CI was still referring to the `documentation-v2` repository name, so I fixed that.
- The lint check wasn't executed in the CI, which is a mistake
- Fixed a linter error to make the CI pass