### PR TITLE
[JS SDK] auth:createCredentials does not return the password

### DIFF
--- a/src/sdk-reference/js/6/auth/create-my-credentials/snippets/create-my-credentials.js
+++ b/src/sdk-reference/js/6/auth/create-my-credentials/snippets/create-my-credentials.js
@@ -5,7 +5,7 @@ await kuzzle.auth.login('local', credentials);
 const response = await kuzzle.auth.createMyCredentials('other', credentials);
 console.log(response);
 /*
-  { username: 'foo', password: 'bar' }
+  { username: 'foo', kuid: '<user unique identifier>' }
 */
 
 console.log('Credentials successfully created');

--- a/src/sdk-reference/js/6/auth/get-my-credentials/snippets/get-my-credentials.js
+++ b/src/sdk-reference/js/6/auth/get-my-credentials/snippets/get-my-credentials.js
@@ -6,7 +6,7 @@ try {
   const localCredentials = await kuzzle.auth.getMyCredentials('local');
   console.log(localCredentials);
   /*
-    {  username: 'foo', kuid: 'foo' }
+    {  username: 'foo', kuid: '<user unique identifier>' }
   */
 
   console.log('Success');


### PR DESCRIPTION
# Description

In the `auth:createCredentials` snippet for the JS SDK, it is said that the API returns the user's password.

This is obviously NOT the case: https://docs.kuzzle.io/sdk-reference/js/6/auth/create-my-credentials/#usage