### PR TITLE
Fix misleading doc for getMapping js api

### DIFF
--- a/helpers/handlebars.js
+++ b/helpers/handlebars.js
@@ -66,8 +66,7 @@ module.exports = {
     return new SafeString(title);
   },
 
-  since: version => `<p class="since">Added in v${version}</p>`,
+  since: version => `<p class="since">Added in ${version}</p>`,
 
-  deprecated: version => `<p class="deprecated">Deprecated since v${version}</p>`
+  deprecated: version => `<p class="deprecated">Deprecated since ${version}</p>`
 };
-

--- a/src/api/1/controller-collection/create/index.md
+++ b/src/api/1/controller-collection/create/index.md
@@ -11,9 +11,15 @@ Creates a new [collection]({{ site_base_path }}guide/1/essentials/persisted), in
 
 {{{since "1.3.0"}}}
 
-You can also provide an optional body with a data mapping that allow you to exploit the full capabilities of our persistent data storage layer.
+You can also provide an optional body with a [collection mapping]({{ site_base_path }}guide/1/essentials/database-mappings) allowing you to exploit the full capabilities of our persistent data storage layer.
 
-This method will only update the mapping if the collection already exists.
+This method will only update the mapping when the collection already exists.
+
+{{{since "1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
 
 ---
 
@@ -29,6 +35,10 @@ Body:
 
 ```js
 {
+  "dynamic": "[false|true|strict]",
+  "_meta": {
+    "field": "value"
+  },
   "properties": {
     "field1": { 
       "type": "integer"
@@ -37,8 +47,8 @@ Body:
       "type": "keyword"
     },
     "field3": {
-        "type":   "date",
-        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+      "type":   "date",
+      "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
     }
   }
 }
@@ -54,6 +64,10 @@ Body:
   "controller": "collection",
   "action": "create",
   "body": {
+    "dynamic": "[false|true|strict]",
+    "_meta": {
+      "field": "value"
+    },
     "properties": {
       "field1": { 
         "type": "integer"
@@ -62,8 +76,8 @@ Body:
         "type": "keyword"
       },
       "field3": {
-          "type":   "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+        "type":   "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
       }
     }
   }
@@ -74,8 +88,8 @@ Body:
 
 ## Arguments
 
-* `collection`: collection name to create
-* `index`: index name that will host the new collection
+* `collection`: name of the collection to create
+* `index`: index that will host the new collection
 
 ---
 
@@ -83,7 +97,9 @@ Body:
 
 ### Optional:
 
-* `properties`: object describing the data mapping to associate to the new collection, using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+* `dynamic`: [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) for new fields. Allowed values: `true` (default), `false`, `strict`
+* `_meta`: [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) stored next to the collection
+* `properties`: object describing the data mapping to associate to the new collection, using [Elasticsearch types definitions format]({{ site_base_path}}guide/1/essentials/database-mappings/#properties-types-definition)
 
 ---
 

--- a/src/api/1/controller-collection/get-mapping/index.md
+++ b/src/api/1/controller-collection/get-mapping/index.md
@@ -7,7 +7,11 @@ title: getMapping
 
 {{{since "1.0.0"}}}
 
-Returns a collection mapping.
+Returns the collection mapping.
+
+{{{since "1.7.1"}}}
+
+Also returns the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) and [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata).
 
 ---
 
@@ -47,13 +51,17 @@ Returns a mapping object with the following structure:
 
 ```
 <index>
-   |- mappings
-         |- <collection>
-               |- properties
-                     |- mapping for field 1
-                     |- mapping for field 2
-                     |- ...
-                     |- mapping for field n
+  |- mappings
+    |- <collection>
+      |- dynamic
+      |- _meta
+        |- metadata 1
+        |- metadata 1
+      |- properties
+        |- mapping for field 1
+        |- mapping for field 2
+        |- ...
+        |- mapping for field n
 ```
 
 ### Example:
@@ -71,16 +79,16 @@ Returns a mapping object with the following structure:
     "<index>": {
       "mappings": {
         "<collection>": {
+          "dynamic": "true",
+          "_meta": {
+            "metadata1": "value1"
+          },
           "properties": {
-            "field1": { 
-              "type": "integer"
-            },
-            "field2": {
-              "type": "keyword"
-            },
+            "field1": { "type": "integer" },
+            "field2": { "type": "keyword" },
             "field3": {
-                "type":   "date",
-                "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+              "type":   "date",
+              "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
             }
           }
         }

--- a/src/api/1/controller-collection/update-mapping/index.md
+++ b/src/api/1/controller-collection/update-mapping/index.md
@@ -9,6 +9,12 @@ title: updateMapping
 
 Updates a collection mapping.
 
+{{{since "1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
+
 ---
 
 ## Query Syntax
@@ -23,6 +29,10 @@ Body:
 
 ```js
 {
+  "dynamic": "[true|false|strict]",
+  "_meta": {
+    "field": "value"
+  },
   "properties": {
     "field1": { 
       "type": "integer"
@@ -31,8 +41,8 @@ Body:
       "type": "keyword"
     },
     "field3": {
-        "type":   "date",
-        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+      "type":   "date",
+      "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
     }
   }
 }
@@ -46,8 +56,11 @@ Body:
   "collection": "<collection>",
   "controller": "collection",
   "action": "updateMapping",
-
   "body": {
+  "dynamic": "[true|false|strict]",
+    "_meta": {
+      "field": "value"
+    },
     "properties": {
       "field1": { 
         "type": "integer"
@@ -56,8 +69,8 @@ Body:
         "type": "keyword"
       },
       "field3": {
-          "type":   "date",
-          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+        "type":   "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
       }
     }
   }
@@ -68,14 +81,18 @@ Body:
 
 ## Arguments
 
-* `collection`: collection name
-* `index`: index name
+* `collection`: name of the collection to update
+* `index`: index that will host the new collection
 
 ---
 
 ## Body properties
 
-* `properties`: object describing the data mapping to associate to the new collection, using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+### Optional:
+
+* `dynamic`: [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) for new fields. Allowed values: `true` (default), `false`, `strict`
+* `_meta`: [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) stored next to the collection
+* `properties`: object describing the data mapping to associate to the new collection, using [Elasticsearch types definitions format]({{ site_base_path}}guide/1/essentials/database-mappings/#properties-types-definition)
 
 ---
 

--- a/src/guide/1/essentials/database-mappings/index.md
+++ b/src/guide/1/essentials/database-mappings/index.md
@@ -1,0 +1,175 @@
+---
+layout: full.html.hbs
+title: Define database mappings
+order: 400
+---
+
+# Database mappings
+
+With Elasticsearch, it is possible to define mappings for collections. These mappings allow you to configure the way Elasticsearch will handle these collections.
+
+There are 3 root fields for mapping configuration:
+ - [properties]({{ site_base_path}}guide/1/essentials/database-mappings/#properties-types-definition): collection types definition
+ - [dynamic]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy): dynamic mapping policy against new fields
+ - [_meta]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata): collection metadata
+
+The following API methods can be used to modify these mappings:
+ - [collection:create]({{ site_base_path }}api/1/controller-collection/create/)
+ - [collection:updateMapping]({{ site_base_path }}api/1/controller-collection/update-mapping/)
+
+---
+
+## Properties types definition
+
+The field type definitions that will be inserted in a collection allow Elasticsearch to index your data for future searches.  
+
+Especially when searching on fields with special types such as `date` or `geo_shape`.
+
+<div class="alert alert-warning">
+Once a type has been defined for a field, it is not possible to modify it later.
+</div>
+
+Refer to the Elasticsearch documentation for an exhaustive list of available types: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping-types.html
+
+### Example
+
+If I want the following document to be correctly indexed:
+```javascript
+{
+  "category": "limousine",
+  "distance": 120990,
+  "position": {
+    "lat": 27.730400,
+    "lon": 85.328467
+  },
+  "driver": {
+    "name": "liia mhe ry"
+  }
+}
+```
+
+The following mapping must first be defined:
+```javascript
+{
+  "properties": {
+    "category": { "type": "keyword" },
+    "distance": { "type": "integer" },
+    "position": { "type": "geo_point" },
+    "driver": {
+      "properties": {
+        "name": { "type": "keyword" }
+      }
+    }
+  }
+}
+```
+
+This mapping is then passed in the body to the methods [collection:create]({{ site_base_path }}api/1/controller-collection/create/) or [collection:updateMapping]({{ site_base_path }}api/1/controller-collection/update-mapping/).
+
+```bash
+# First create a collection yellow-taxi in the nyc-open-data index
+curl -X PUT -d '{"properties":{"category":{"type":"keyword"},"distance":{"type":"integer"},"position":{"type":"geo_point"},"driver":{"properties":{"name":{"type":"keyword"}}}}}' -H "Content-Type: application/json" "http://localhost:7512/nyc-open-data/yellow-taxi?pretty"
+
+# Then create the desired document
+curl -X POST -d '{"category":"limousine","distance":120990,"position":{"lat":27.7304,"lon":85.328467},"driver":{"name":"liia meh ry"}}' -H "Content-Type: application/json" "http://localhost:7512/nyc-open-data/yellow-taxi/_create?pretty"
+```
+
+<div class="alert alert-warning">
+Because of the way Elasticsearch manages collections, mappings are shared between indexes.
+<br/>
+This means that if I have an index <code>nyc-open-data</code>, two collections <code>yellow-taxi</code> and <code>green-taxi</code> and a field <code>name</code> with type <code>keyword</code> in the collection <code>yellow-taxi</code>, then I can't have a field <code>name</code> with a different type in the collection <code>green-taxi</code>.
+</div>
+
+---
+
+## Dynamic mapping policy
+
+For each collection, you can set the policy against new fields that are not referenced in the collection mapping by modifying the `dynamic` root field.
+
+The value of this configuration will change the way Elasticsearch manages the creation of new fields that are not declared in the collection mapping.
+  - `"true"`: Stores the document and updates the collection mapping with the inferred type
+  - `"false"`: Stores the document and does not update the collection mapping (fields are not indexed)
+  - `"strict"`: Rejects the document
+
+Refer to Elasticsearch documentation for more informations: https://www.elastic.co/guide/en/elasticsearch/guide/current/dynamic-mapping.html
+
+The default policy for new collections is `"true"` and is configurable in the [kuzzlerc]({{ site_base_path }}guide/1/essentials/configuration/) file under the key `services.db.dynamic`.
+
+<div class="alert alert-warning">
+We advise not to let Elasticsearch dynamically infer the type of new fields in production.
+<br/>
+This can be a problem because then the mapping cannot be modified.
+</div>
+
+It is also possible to specify a different dynamic mapping policy for nested fields. This can be useful in imposing a strict policy on the collection while allowing the introduction of new fields in a specific location.
+  
+### Example
+
+If you want a `strict` dynamic policy for your entire collection, you have to define it in root level but you can have a different policy for nested types:
+
+```javascript
+{
+  "dynamic": "strict"
+  "properties": {
+    "driver": {
+      "dynamic": "false"
+      "properties": // allow insertion of new fields in the driver nested field
+    }
+  }
+}
+```
+<br/>
+```bash
+# Define a strict dynamic policy for the yellow-taxi collection
+curl -X PUT -d '{ "dynamic": "strict" }' -H "Content-Type: application/json"  "http://localhost:7512/nyc-open-data/yellow-taxi?pretty"
+
+# Try to create a document with a field that is not referenced in the mapping
+curl -X POST -d '{"language":"nepali"}' -H "Content-Type: application/json" "http://localhost:7512/nyc-open-data/yellow-taxi/_create?pretty"
+
+# You should see an error with the following message:
+# "mapping set to strict, dynamic introduction of [language] within [yellow-taxi] is not allowed"
+```
+
+---
+
+## Collection metadata
+
+Elasticsearch allows the definition of metadata that is stored next to the collections in the root field `_meta`.  
+These metadata are ignored by Elasticsearch, they can contain any type of information specific to your application.
+
+<div class="alert alert-warning">
+Unlike the properties types definition, new collection metadata are not merged with the old one.
+<br/>
+If you set the <code>_meta</code> field in your request, the old value will be overwritten.
+</div>
+
+Refer to Elasticsearch documentation for more informations: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping-meta-field.html
+
+These metadata can be retrieved with the [collection:getMapping]({{ site_base_path }}api/1/controller-collection/get-mapping/) API method.
+
+### Example
+
+```javascript
+{
+  "_meta": {
+    "area": "Panipokhari"
+  }
+}
+```
+<br/>
+```bash
+# Add collection metadata
+curl -X PUT -d '{ "_meta": { "area": "Panipokhari" } }' -H "Content-Type: application/json"  "http://localhost:7512/nyc-open-data/yellow-taxi/_mapping?pretty"
+
+# Retrieve it
+curl -X GET -H "Content-Type: application/json"  "http://localhost:7512/nyc-open-data/yellow-taxi/_mapping?pretty"
+```
+
+---
+
+## What Now?
+
+* Learn to work with [Persistent Data]({{ site_base_path }}guide/1/essentials/persisted)
+* Read our [Elasticsearch Cookbook]({{ site_base_path }}guide/1/elasticsearch) to learn more about how querying works in Kuzzle
+* Use [document metadata]({{ site_base_path }}guide/1/essentials/document-metadata) to find or recover documents
+* Keep track of data changes using [Real-time Notifications]({{ site_base_path }}guide/1/essentials/real-time)

--- a/src/guide/1/essentials/persisted/index.md
+++ b/src/guide/1/essentials/persisted/index.md
@@ -84,7 +84,7 @@ You should receive the following response:
 }
 ```
 
-**Note:**  we have just created a new collection without specifying any mappings. As a result, the database layer will automatically create a mapping that assigns a best guess data type to any new field it detects in input documents. Since these mappings cannot be changed once they are created, we strongly recommend that you [**create your own mappings**]({{ site_base_path }}guide/1/essentials/persisted/#mappings) as soon as the collection has been created. For the purpose of this tutorial, we will continue without defining our own mappings.
+**Note:**  we have just created a new collection without specifying any mappings. As a result, the database layer will automatically create a mapping that assigns a best guess data type to any new field it detects in input documents. Since these mappings cannot be changed once they are created, we strongly recommend that you [**create your own mappings**]({{ site_base_path }}guide/1/essentials/database-mappings) as soon as the collection has been created. For the purpose of this tutorial, we will continue without defining our own mappings.
 
 ---
 
@@ -489,56 +489,6 @@ You should receive the following response (with your own `_id` values):
   }
 }
 ```
-
----
-
-## Mappings
-
-Kuzzle uses Elasticsearch as a persistent document store, which uses mappings to assign a type to a document field. These mappings are attached to a `collection` (aka `type` in Elasticsearch terminology) and are automatically inferred from input documents if no mappings are preconfigured.
-
-If you want to control how Kuzzle interprets your documents, we recommend that you configure your own mappings using our mappings creation endpoint.
-
-Create a mapping by sending a `PUT` request to the `http://localhost:7512/<index name>/<collection name>/_mapping` and setting the mapping in the request body.
-
-Use [this](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html) syntax when definng a mapping. For example, if we want to create a mapping that will define a field `birthday` as a `date` type, we would send the following JSON in the body:
-
-```json
-{
-  "properties": {
-    "birthday": {
-      "type": "date"
-    }
-  }
-}
-```
-
-Let's try it:
-
-```bash
- curl -X PUT -H "Content-Type: application/json" -d '{"properties":{"birthday":{"type": "date"}}}' http://localhost:7512/myindex/mycollection/_mapping
-```
-
-You should receive the following response:
-
-```json
-{
-  "requestId": "<random unique request id>",
-  "status": 200,
-  "error": null,
-  "controller": "collection",
-  "action": "updateMapping",
-  "collection": "mycollection",
-  "index": "myindex",
-  "volatile": null,
-  "result": {
-    "acknowledged": true
-  }
-}
-```
-
-Here we have now defined the type `date` for the field labeled `birthday` in our `mycollection` collection. Defining types in this way can be especially useful when dealing with specific types (`date`, `geo_shape`, etc.), full-text search, or complex data structures.
-
-Please note that the mappings of a collection cannot be updated once they are created, this is true whether you create the rules yourself using our API or whether Elasticsearch generates the rules automatically based on the input documents it processes. Because of this, you should almost always define mappings when you first create your collections and before creating any documents.
 
 ---
 

--- a/src/sdk-reference/cpp/1/collection/create/index.md
+++ b/src/sdk-reference/cpp/1/collection/create/index.md
@@ -6,11 +6,19 @@ description: Create a new collection
 
 # create
 
-Creates a new [collection]({{ site_base_path }}guide/1/essentials/persisted) in Kuzzle via the persistence engine, in the provided `index`.
-You can also provide an optional data mapping that allow you to exploit the full capabilities of our
-persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html)).
+Creates a new [collection]({{ site_base_path }}guide/1/essentials/persisted) in Kuzzle via the persistence engine, in the provided index.
 
-This method will only update the mapping if the collection already exists.
+{{{since "Kuzzle 1.3.0"}}}
+
+You can also provide an optional body with a [collection mapping]({{ site_base_path }}guide/1/essentials/database-mappings) that allow you to exploit the full capabilities of our persistent data storage layer.
+
+This method will only update the mapping when the collection already exists.
+
+{{{since "Kuzzle 1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
 
 ## Signature
 
@@ -40,16 +48,19 @@ void create(
 |--------------|---------|-------------|
 | `index` | <pre>const std::string&</pre> | Index name    | 
 | `collection` | <pre>const std::string&</pre> | Collection name    |
-| `mapping` | <pre>const std::string*</pre> | JSON string representing the collection data mapping  |
+| `mapping` | <pre>const std::string*</pre> | JSON string representing the collection mapping  |
 | `options` | <pre>kuzzleio::query_options\*</pre> |  Query options  |
 
 ### mapping
 
-A JSON string representing the collection data mapping.
+A JSON string representing the collection mapping.
 
-The mapping must have a root field `properties` that contain the mapping definition:
 ```json
 {
+  "dynamic": "[true|false|strict]",
+  "_meta": {
+    "field": "value"
+  },
   "properties": {
     "field1": { "type": "text" },
     "field2": {
@@ -61,7 +72,7 @@ The mapping must have a root field `properties` that contain the mapping definit
 }
 ```
 
-You can see the full list of Elasticsearch mapping types [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+More informations about database mappings [here]({{ site_base_path}}guide/1/essentials/database-mappings).
 
 ### options
 

--- a/src/sdk-reference/cpp/1/collection/create/snippets/create.cpp
+++ b/src/sdk-reference/cpp/1/collection/create/snippets/create.cpp
@@ -1,5 +1,9 @@
 try {
   std::string mapping = R"({
+    "dynamic": "false",
+    "_meta": {
+      "area": "Panipokhari"
+    },
     "properties": {
       "license": { "type": "keyword" },
       "driver": {

--- a/src/sdk-reference/cpp/1/collection/get-mapping/index.md
+++ b/src/sdk-reference/cpp/1/collection/get-mapping/index.md
@@ -37,7 +37,7 @@ Additional query options
 
 ## Return
 
-A JSON string representing the collection data mapping.
+A JSON string representing the collection mapping.
 
 ## Usage
 

--- a/src/sdk-reference/cpp/1/collection/get-mapping/snippets/get-mapping.cpp
+++ b/src/sdk-reference/cpp/1/collection/get-mapping/snippets/get-mapping.cpp
@@ -2,7 +2,7 @@ try {
   std::string mapping = kuzzle->collection->getMapping("nyc-open-data", "yellow-taxi");
 
   std::cout << mapping << std::endl;
-  // {"properties":{"license":{"type":"keyword"},"driver":{"properties":{"name":{"type":"keyword"},"curriculum":{"type":"text"}}}}}
+  // {"dynamic": "false","_meta": { "area": "Panipokhari" }, "properties":{"license":{"type":"keyword"},"driver":{"properties":{"name":{"type":"keyword"},"curriculum":{"type":"text"}}}}}
 } catch (kuzzleio::KuzzleException &e) {
   std::cerr << e.what() << std::endl;
 }

--- a/src/sdk-reference/cpp/1/collection/update-mapping/index.md
+++ b/src/sdk-reference/cpp/1/collection/update-mapping/index.md
@@ -6,9 +6,13 @@ description: Update the collection mapping
 
 # updateMapping
 
-Update the collection mapping.
-Mapping allow you to exploit the full capabilities of our
-persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html)).
+Updates a collection mapping.
+
+{{{since "Kuzzle 1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
 
 ## Signature
 
@@ -31,16 +35,19 @@ void updateMapping(
 |--------------|---------|-------------|
 | `index` | <pre>const std::string&</pre> | Index name    | 
 | `collection` | <pre>const std::string&</pre> | Collection name    |
-| `mapping` | <pre>const std::string*</pre> | JSON string representing the collection data mapping |
+| `mapping` | <pre>const std::string*</pre> | JSON string representing the collection mapping |
 | `options` | <pre>kuzzleio::query_options\*</pre> |  Query options  |
 
 ### mapping
 
-A JSON string representing the collection data mapping.
+A JSON string representing the collection mapping.
 
-The mapping must have a root field `properties` that contain the mapping definition:
 ```json
 {
+  "dynamic": "[true|false|strict]",
+  "_meta": {
+    "field": "value"
+  },
   "properties": {
     "field1": { "type": "text" },
     "field2": {
@@ -52,7 +59,8 @@ The mapping must have a root field `properties` that contain the mapping definit
 }
 ```
 
-You can see the full list of Elasticsearch mapping types [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+More informations about database mappings [here]({{ site_base_path}}guide/1/essentials/database-mappings).
+
 
 ### options
 

--- a/src/sdk-reference/cpp/1/collection/update-mapping/snippets/update-mapping.cpp
+++ b/src/sdk-reference/cpp/1/collection/update-mapping/snippets/update-mapping.cpp
@@ -1,5 +1,9 @@
 try {
   std::string mapping = R"({
+    "dynamic": "false",
+    "_meta": {
+      "area": "Panipokhari"
+    },
     "properties": {
       "plate": { "type": "keyword" }
     }

--- a/src/sdk-reference/go/1/collection/create/index.md
+++ b/src/sdk-reference/go/1/collection/create/index.md
@@ -6,9 +6,19 @@ description: Create a new collection
 
 # create
 
-Creates a new [collection]({{ site_base_path }}guide/1/essentials/persisted) in Kuzzle via the persistence engine, in the provided `index`.  
-You can also provide an optional data mapping that allow you to exploit the full capabilities of our
-persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html)).  
+Creates a new [collection]({{ site_base_path }}guide/1/essentials/persisted) in Kuzzle via the persistence engine, in the provided index.
+
+{{{since "Kuzzle 1.3.0"}}}
+
+You can also provide an optional body with a [collection mapping]({{ site_base_path }}guide/1/essentials/database-mappings) that allow you to exploit the full capabilities of our persistent data storage layer.
+
+This method will only update the mapping when the collection already exists.
+
+{{{since "Kuzzle 1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
 
 This method will only update the mapping if the collection already exists.
 
@@ -24,16 +34,19 @@ Create(index string, collection string, mapping json.RawMessage, options types.Q
 |--------------|---------|-------------|----------
 | ``index`` | string | Index name    | yes  |
 | ``collection`` | string | Collection name    | yes  |
-| ``mapping`` | json.RawMessage | Collection data mapping in JSON format  | no  |
+| ``mapping`` | json.RawMessage | Collection mapping in JSON format  | no  |
 | `options` | QueryOptions | Query options | no       |
 
-### **mapping**
+### mapping
 
-An string containing the JSON representation of the collection data mapping.  
+A `json.RawMessage` containing the representation of the collection mapping.  
 
-The mapping must have a root field `properties` that contain the mapping definition:
 ```json
 {
+  "dynamic": "[true|false|strict]",
+  "_meta": {
+    "field": "value"
+  },
   "properties": {
     "field1": { "type": "text" },
     "field2": {
@@ -45,9 +58,9 @@ The mapping must have a root field `properties` that contain the mapping definit
 }
 ```
 
-You can see the full list of Elasticsearch mapping types [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html).
+More informations about database mappings [here]({{ site_base_path}}guide/1/essentials/database-mappings)
 
-### **options**
+### options
 
 Additional query options
 

--- a/src/sdk-reference/go/1/collection/create/snippets/create.go
+++ b/src/sdk-reference/go/1/collection/create/snippets/create.go
@@ -1,4 +1,4 @@
-mapping := json.RawMessage(`{"properties":{"license": {"type": "keyword"}}}`)
+mapping := json.RawMessage(`{ "dynamic": "false","_meta": { "area": "Panipokhari" }, "properties":{"license": {"type": "keyword"}}}`)
 err := kuzzle.Collection.Create("nyc-open-data", "yellow-taxi", mapping, nil)
 
 if err != nil {

--- a/src/sdk-reference/go/1/collection/update-mapping/index.md
+++ b/src/sdk-reference/go/1/collection/update-mapping/index.md
@@ -6,9 +6,13 @@ description: Update the collection mapping
 
 # updateMapping
 
-Update the collection mapping.  
-Mapping allow you to exploit the full capabilities of our
-persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html)).
+Updates a collection mapping.
+
+{{{since "Kuzzle 1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
 
 ## Signature
 
@@ -22,16 +26,19 @@ UpdateMapping(index string, collection string, mapping json.RawMessage, options 
 |--------------|---------|-------------|----------
 | ``index`` | string | Index name    | yes  |
 | ``collection`` | string | Collection name    | yes  |
-| ``mapping`` | json.RawMessage | Collection data mapping in JSON format  | yes  |
+| ``mapping`` | json.RawMessage | Collection mapping in JSON format  | yes  |
 | `options` | QueryOptions | Query options | no       |
 
-### **mapping**
+### mapping
 
-An string containing the JSON representation of the collection data mapping.  
+A `json.RawMessage` containing the representation of the collection mapping.  
 
-The mapping must have a root field `properties` that contain the mapping definition:
 ```json
 {
+  "dynamic": "[true|false|strict]",
+  "_meta": {
+    "field": "value"
+  },
   "properties": {
     "field1": { "type": "text" },
     "field2": {
@@ -43,9 +50,9 @@ The mapping must have a root field `properties` that contain the mapping definit
 }
 ```
 
-You can see the full list of Elasticsearch mapping types [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html).
+More informations about database mappings [here]({{ site_base_path}}guide/1/essentials/database-mappings)
 
-### **options**
+### options
 
 Additional query options
 

--- a/src/sdk-reference/go/1/collection/update-mapping/snippets/update-mapping.go
+++ b/src/sdk-reference/go/1/collection/update-mapping/snippets/update-mapping.go
@@ -1,4 +1,4 @@
-mapping := json.RawMessage(`{"properties":{"plate": {"type": "keyword"}}}`)
+mapping := json.RawMessage(`{ "dynamic": "false","_meta": { "area": "Panipokhari" }, "properties":{"plate": {"type": "keyword"}}}`)
 err := kuzzle.Collection.UpdateMapping("nyc-open-data", "yellow-taxi", mapping, nil)
 
 if err != nil {

--- a/src/sdk-reference/js/6/collection/create/index.md
+++ b/src/sdk-reference/js/6/collection/create/index.md
@@ -8,10 +8,17 @@ description: Create a new collection
 
 Creates a new [collection]({{ site_base_path }}guide/1/essentials/persisted) in Kuzzle via the persistence engine, in the provided index.
 
-You can also provide an optional data mapping that allow you to exploit the full capabilities of our
-persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html)).
+{{{since "Kuzzle 1.3.0"}}}
 
-This method will only update the mapping if the collection already exists.
+You can also provide an optional body with a [collection mapping]({{ site_base_path }}guide/1/essentials/database-mappings) that allow you to exploit the full capabilities of our persistent data storage layer.
+
+This method will only update the mapping when the collection already exists.
+
+{{{since "Kuzzle 1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
 
 <br/>
 
@@ -25,16 +32,19 @@ create (index, collection, [mapping], [options])
 |--------------|---------|-------------|
 | ``index`` | <pre>string</pre> | Index name    |
 | ``collection`` | <pre>string</pre> | Collection name    |
-| ``mapping`` | <pre>object</pre> | Describes the data mapping to associate to the new collection, using Elasticsearch [mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html)    |
+| ``mapping`` | <pre>object</pre> | Describes the collection mapping   |
 | ``options`` | <pre>object</pre> | Query options    |
 
 ### mapping
 
 An object representing the data mapping of the collection.
 
-The mapping must have a root field `properties` that contain the mapping definition:
 ```js
 const mapping = {
+  dynamic: '[true|false|strict]',
+  _meta: {
+    field: 'value'
+  },
   properties: {
     field1: { type: 'text' },
     field2: {
@@ -46,7 +56,7 @@ const mapping = {
 };
 ```
 
-You can see the full list of Elasticsearch mapping types [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+More informations about database mappings [here]({{ site_base_path}}guide/1/essentials/database-mappings)
 
 ### options
 

--- a/src/sdk-reference/js/6/collection/create/snippets/create.js
+++ b/src/sdk-reference/js/6/collection/create/snippets/create.js
@@ -1,4 +1,8 @@
 const mapping = {
+  dynamic: 'false',
+  _meta: {
+    area: 'Panipokhari'
+  },
   properties: {
     license: { type: 'keyword' },
     driver: {

--- a/src/sdk-reference/js/6/collection/get-mapping/index.md
+++ b/src/sdk-reference/js/6/collection/get-mapping/index.md
@@ -6,7 +6,7 @@ description: Return collection mapping
 
 # getMapping
 
-Returns a collection mapping.
+Returns the collection mapping.
 
 <br/>
 

--- a/src/sdk-reference/js/6/collection/get-mapping/index.md
+++ b/src/sdk-reference/js/6/collection/get-mapping/index.md
@@ -34,6 +34,31 @@ Additional query options
 
 Resolves to an `object` representing the collection mapping.
 
+Example :
+```js
+{
+  "<index>": {             // The provided <index>
+    "mappings": {
+      "<collection>": {    // The provided <collection>
+        // The actual mapping of the collection starts here:
+        "properties": {
+          "field1": {
+            "type": "integer"
+          },
+          "field2": {
+            "type": "keyword"
+          },
+          "field3": {
+              "type":   "date",
+              "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Usage
 
 [snippet=get-mapping]

--- a/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
+++ b/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
@@ -1,25 +1,38 @@
 try {
   const mapping = await kuzzle.collection.getMapping('nyc-open-data', 'yellow-taxi');
   console.log(mapping);
+
   /*
-    {
-      dynamic: 'false',
-      _meta: {
-        area: 'Panipokhari
-      },
-      properties: {
-        license: { type: 'keyword' },
-        driver: {
-          properties: {
-            name: { type: 'keyword' },
-            curriculum: { type: 'text' }
+  {
+    "nyc-open-data": {
+      "mappings": {
+        "yellow-taxi": {
+          "dynamic": "false",
+          "_meta": {
+            "area": "Panipokhari"
+          },
+          "properties": {
+            "license": {
+              "type": "keyword"
+            },
+            "driver": {
+              "properties": {
+                "name": {
+                  "type": "keyword"
+                },
+                "curriculum": {
+                  "type": "text"
+                }
+              }
+            }
           }
         }
       }
     }
+  }
   */
 
-  console.log('Success');
+  console.log('uccess');
 } catch (error) {
   console.error(error.message);
 }

--- a/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
+++ b/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
@@ -3,6 +3,10 @@ try {
   console.log(mapping);
   /*
     {
+      dynamic: 'false',
+      _meta: {
+        area: 'Panipokhari
+      },
       properties: {
         license: { type: 'keyword' },
         driver: {

--- a/src/sdk-reference/js/6/collection/update-mapping/index.md
+++ b/src/sdk-reference/js/6/collection/update-mapping/index.md
@@ -8,6 +8,12 @@ description: Update the collection mapping
 
 Updates a collection mapping.
 
+{{{since "Kuzzle 1.7.1"}}}
+
+You can define the collection [dynamic mapping policy]({{ site_base_path}}guide/1/essentials/database-mappings/#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata]({{ site_base_path}}guide/1/essentials/database-mappings/#collection-metadata) within the `_meta` root field.
+
 <br/>
 
 ```javascript
@@ -20,28 +26,31 @@ updateMapping (index, collection, mapping, [options])
 |--------------|---------|-------------|
 | ``index`` | <pre>string</pre> | Index name    |
 | ``collection`` | <pre>string</pre> | Collection name    |
-| ``mapping`` | <pre>object</pre> | Describes the data mapping to associate to the new collection, using Elasticsearch [mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html) |
+| ``mapping`` | <pre>object</pre> | Describes the collection mapping |
 | ``options`` | <pre>object</pre> | Query options    |
 
 ### mapping
 
-An object representing the collection data mapping.
+An object representing the data mapping of the collection.
 
-This object must have a root field `properties` that contain the mapping definition:
-```javascript
+```js
 const mapping = {
+  dynamic: '[true|false|strict]',
+  _meta: {
+    field: 'value'
+  },
   properties: {
     field1: { type: 'text' },
     field2: {
       properties: {
-        nestedField: { type: 'keyword' }
+        nestedField: { type: 'keyword'}
       }
     }
   }
 };
 ```
 
-You can see the full list of Elasticsearch mapping types [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping-types.html).
+More informations about database mappings [here]({{ site_base_path}}guide/1/essentials/database-mappings)
 
 ### options
 

--- a/src/sdk-reference/js/6/collection/update-mapping/snippets/update-mapping.js
+++ b/src/sdk-reference/js/6/collection/update-mapping/snippets/update-mapping.js
@@ -1,4 +1,8 @@
 const mapping = {
+  dynamic: 'false',
+  _meta: {
+    area: 'Panipokhari'
+  },
   properties: {
     plate: { type: 'keyword' }
   }


### PR DESCRIPTION

## What does this PR do?
Disambiguate `getMapping` sample response in JS 6 SDK documentation.

### How should this be manually tested?

read the doc at HERE  and it should make clear to you that you will indeed receive the same response as when using the REST API: https://docs.kuzzle.io/api/1/controller-collection/get-mapping/
