### PR TITLE
doc: disambiguation of getMapping sample response in JS SDK

### DIFF
--- a/src/sdk-reference/js/6/collection/get-mapping/index.md
+++ b/src/sdk-reference/js/6/collection/get-mapping/index.md
@@ -34,6 +34,31 @@ Additional query options
 
 Resolves to an `object` representing the collection mapping.
 
+Example :
+```js
+{
+  "<index>": {             // The provided <index>
+    "mappings": {
+      "<collection>": {    // The provided <collection>
+        // The actual mapping of the collection starts here:
+        "properties": {
+          "field1": {
+            "type": "integer"
+          },
+          "field2": {
+            "type": "keyword"
+          },
+          "field3": {
+              "type":   "date",
+              "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Usage
 
 [snippet=get-mapping]

--- a/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
+++ b/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
@@ -1,21 +1,38 @@
 try {
   const mapping = await kuzzle.collection.getMapping('nyc-open-data', 'yellow-taxi');
   console.log(mapping);
+
   /*
-    {
-      properties: {
-        license: { type: 'keyword' },
-        driver: {
-          properties: {
-            name: { type: 'keyword' },
-            curriculum: { type: 'text' }
+  {
+    "nyc-open-data": {
+      "mappings": {
+        "yellow-taxi": {
+          "dynamic": "false",
+          "_meta": {
+            "area": "Panipokhari"
+          },
+          "properties": {
+            "license": {
+              "type": "keyword"
+            },
+            "driver": {
+              "properties": {
+                "name": {
+                  "type": "keyword"
+                },
+                "curriculum": {
+                  "type": "text"
+                }
+              }
+            }
           }
         }
       }
     }
+  }
   */
 
-  console.log('Success');
+  console.log('uccess');
 } catch (error) {
   console.error(error.message);
 }

--- a/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
+++ b/src/sdk-reference/js/6/collection/get-mapping/snippets/get-mapping.js
@@ -32,7 +32,7 @@ try {
   }
   */
 
-  console.log('uccess');
+  console.log('Success');
 } catch (error) {
   console.error(error.message);
 }


### PR DESCRIPTION
## What does this PR do?
Disambiguate `getMapping` sample response in JS 6 SDK documentation.

### How should this be manually tested?

read the doc at HERE  and it should make clear to you that you will indeed receive the same response as when using the REST API: https://docs.kuzzle.io/api/1/controller-collection/get-mapping/
