### PR TITLE
[SDK] fix index:refreshInternal arguments list

### DIFF
--- a/src/sdk-reference/go/1/index/refresh-internal/index.md
+++ b/src/sdk-reference/go/1/index/refresh-internal/index.md
@@ -17,26 +17,25 @@ The `refreshInternal` action forces a [refresh]({{ ../site_base_path }}/sdk-refe
   "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
 </div>
 
-## Signature
-
-```go
-RefreshInternal(index string, options types.QueryOptions) error
-```
-
 ## Arguments
 
-| Arguments | Type         | Description                           | Required |
-| --------- | ------------ | ------------------------------------- | -------- |
-| `index`   | string       | Index name                            | yes      |
-| `options` | QueryOptions | Query options | no       |
+```go
+RefreshInternal(options types.QueryOptions) error
+```
 
-### **Options**
+<br/>
 
-Additional query options
+| Arguments | Type         | Description   |
+| --------- | ------------ | ------------- |
+| `options` | <pre>QueryOptions</pre> | Query options |
 
-| Option     | Type    | Description                       | Default |
-| ---------- | ------- | --------------------------------- | ------- |
-| `queuable` | bool | Make this request queuable or not | `true`  |
+### options
+
+The `options` arguments can contain the following option properties:
+
+| Option     | Type (default) | Description                       |
+| ---------- | -------------- | --------------------------------- |
+| `queuable` | <pre>bool (true)</pre> | If true, queues the request during downtime, until connected to Kuzzle again |
 
 ## Return
 

--- a/src/sdk-reference/java/1/index/refresh-internal/index.md
+++ b/src/sdk-reference/java/1/index/refresh-internal/index.md
@@ -17,27 +17,26 @@ The `refreshInternal` action forces a [refresh]({{ ../site_base_path }}/sdk-refe
   "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
 </div>
 
-## Signature
-
-```java
-void refreshInternal() throws io.kuzzle.sdk.BadRequestException, io.kuzzle.sdk.ForbiddenException, io.kuzzle.sdk.GatewayTimeoutException, io.kuzzle.sdk.InternalException, io.kuzzle.sdk.ServiceUnavailableException;
-void refreshInternal(io.kuzzle.sdk.QueryOptions options) throws io.kuzzle.sdk.BadRequestException, io.kuzzle.sdk.ForbiddenException, io.kuzzle.sdk.GatewayTimeoutException, io.kuzzle.sdk.InternalException, io.kuzzle.sdk.ServiceUnavailableException;
-```
-
 ## Arguments
 
-| Arguments | Type         | Description       | Required |
-| --------- | ------------ | ----------------- | -------- |
-| `index`   | String       | Index name        | yes      |
-| `options` | io.kuzzle.sdk.QueryOptions | The query options | no       |
+```java
+void refreshInternal() throws io.kuzzle.sdk.KuzzleException;
+void refreshInternal(io.kuzzle.sdk.QueryOptions options) throws io.kuzzle.sdk.KuzzleException;
+```
 
-### **Options**
+<br/>
 
-Additional query options
+| Arguments | Type         | Description       |
+| --------- | ------------ | ----------------- |
+| `options` | <pre>io.kuzzle.sdk.QueryOptions</pre> | Query options | 
 
-| Option     | Type    | Description                       | Default |
-| ---------- | ------- | --------------------------------- | ------- |
-| `queuable` | boolean | Make this request queuable or not | `true`  |
+### options
+
+The `options` arguments can contain the following option properties:
+
+| Property   | Type (default)   | Description                       |
+| ---------- | ------- | --------------------------------- |
+| `queuable` | <pre>boolean (true)</pre> | If true, queues the request during downtime, until connected to Kuzzle again |
 
 ## Exceptions
 

--- a/src/sdk-reference/js/6/index/refresh-internal/index.md
+++ b/src/sdk-reference/js/6/index/refresh-internal/index.md
@@ -17,22 +17,21 @@ The `refreshInternal` action forces a [refresh]({{ ../site_base_path }}/sdk-refe
   "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
 </div>
 
-<br/>
+## Arguments
 
 ```javascript
-refreshInternal (index, [options]);
+refreshInternal ([options]);
 ```
 
 <br/>
 
 | Arguments | Type   | Description                         |
 | --------- | ------ | ----------------------------------- |
-| `index`   | <pre>string</pre> | Index name |
 | `options` | <pre>object</pre> | Query options |
 
 ### options
 
-Additional query options
+The `options` arguments can contain the following option properties:
 
 | Property     | Type<br/>(default)    | Description   |
 | -------------- | --------- | ------------- |


### PR DESCRIPTION
# Description

On some SDK, the `index:refreshInternal` API action incorrectly states that it takes an `index` argument.

# Boyscout

Update the documentation template on the fixed pages.