### PR TITLE
Fix erroneous bulk:import example

### DIFF
--- a/src/api/1/controller-bulk/import/index.md
+++ b/src/api/1/controller-bulk/import/index.md
@@ -28,12 +28,13 @@ Body:
 ```js
 {
   "bulkData": [
-    {"create": {}},
-    {"a": "document", "with": "any", "number": "of fields"},
-    {"create": {}},
-    {"another": "document"},
-    {"create": {}},
-    {"and": {"another": "one"}}
+    { "index": {} },
+    { "new": "document", "with": "any", "number": "of fields" },
+    { "create": {"_id": "foobar"} },
+    { "another": "document", "with": "a preset id" },
+    { "delete": {"_id": "existing_document_identifier"} },
+    { "update": {"_id": "another_document"} },
+    { "doc": {"partial": "update"}, "upsert": {"if": "document doesn't exist"} }
   ]
 }
 ```
@@ -46,15 +47,15 @@ Body:
   "collection": "<collection>",
   "controller": "bulk",
   "action": "import",
-
   "body": {
     "bulkData": [
-      {"create": {}},
-      {"a": "document", "with": "any", "number": "of fields"},
-      {"create": {}},
-      {"another": "document"},
-      {"create": {}},
-      {"and": {"another": "one"}}
+      { "index": {} },
+      { "new": "document", "with": "any", "number": "of fields" },
+      { "create": {"_id": "foobar"} },
+      { "another": "document", "with": "a preset id" },
+      { "delete": {"_id": "existing_document_identifier"} },
+      { "update": {"_id": "another_document"} },
+      { "doc": {"partial": "update"}, "upsert": {"if": "document doesn't exist"} }
     ]
   }
 }
@@ -96,21 +97,34 @@ Each query result contains the following properties:
   "result": {
     "items": [
       {
-        "create": {
-          "_id": "<documentId>",
-          "status": 200
+        "index": {
+          "_id": "<randomly generated identifier>",
+          "_version": 1,
+          "result": "created",
+          "created": true
         }
       },
       {
         "create": {
-          "_id": "<documentId>",
-          "status": 200
+          "_id": "foobar",
+          "_version": 1,
+          "result": "created",
+          "created": true
         }
       },
       {
-        "create": {
-          "_id": "<documentId>",
-          "status": 200
+        "delete": {
+          "found": true,
+          "_id": "existing_document_identifier",
+          "_version": 2,
+          "result": "deleted"
+        }
+      },
+      {
+        "update": {
+          "_id": "another_document",
+          "_version": 1,
+          "result": "created"
         }
       }
     ]


### PR DESCRIPTION
# Description

The example given in the API [bulk:import](https://docs.kuzzle.io/api/1/controller-bulk/import/) is incorrect: we cannot use `create` without providing a document identifier.

This PR improves the example by giving a more complete (and correct) import example.