### PR TITLE
[plugins] add missing "since version" tag to the SDK accessor methods

### DIFF
--- a/src/plugins/1/accessors/sdk/index.md
+++ b/src/plugins/1/accessors/sdk/index.md
@@ -60,6 +60,8 @@ async myAwesomePipe (request) {
 
 ## query
 
+{{{since "1.6.0"}}}
+
 Accessor to the [query method]({{ site_base_path }}sdk-reference/js/6/kuzzle/query).  
 This can be useful to call plugins custom controller action.
 
@@ -83,6 +85,8 @@ async myAwesomePipe (request) {
 ---
 
 ## as
+
+{{{since "1.7.0"}}}
 
 Execute the following query as the original request user.
 


### PR DESCRIPTION
# Description

The documentation about the SDK accessor methods `query` and `as` are missing the "since" tag giving the starting version of Kuzzle from which these features are made available.

This is an important information to have since it helps users identifying why some features seem to be missing if their kuzzle instance is too old.

# How to test

Before: https://docs.kuzzle.io/plugins/1/accessors/sdk/

After: <netlify preview>