### PR TITLE
SPA mode

### DIFF
--- a/src/.vuepress/components/Redirect.vue
+++ b/src/.vuepress/components/Redirect.vue
@@ -11,7 +11,7 @@ export default {
     }
   },
   mounted() {
-    window.location = this.to;
+    this.$router.replace(this.to)
   }
 };
 </script>

--- a/src/.vuepress/components/SDKIndex.vue
+++ b/src/.vuepress/components/SDKIndex.vue
@@ -1,39 +1,39 @@
 <template>
   <div class="Tiles">
-    <a :href="generateLink('/sdk/js/6/')" class="Tiles-item">
+    <router-link :to="{path: generateLink('/sdk/js/6/')}" class="Tiles-item">
       <img src="/logos/javascript.svg" alt="js logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Javascript</div>
-    </a>
-    <a :href="generateLink('/sdk/go/1/')" class="Tiles-item">
+    </router-link>
+    <router-link :to="{path: generateLink('/sdk/go/1/')}" class="Tiles-item">
       <div class="ribbon">
         <span>BETA</span>
       </div>
       <img src="/logos/go.svg" alt="golang logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Golang</div>
-    </a>
-    <a :href="generateLink('/sdk/cpp/1/')" class="Tiles-item">
+    </router-link>
+    <router-link :to="{path: generateLink('/sdk/cpp/1/')}" class="Tiles-item">
       <div class="ribbon">
         <span>BETA</span>
       </div>
       <img src="/logos/cpp.svg" alt="c++ logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">C++</div>
-    </a>
-    <a :href="generateLink('/sdk/java/1/')" class="Tiles-item">
+    </router-link>
+    <router-link :to="{path: generateLink('/sdk/java/1/')}" class="Tiles-item">
       <div class="ribbon">
         <span>BETA</span>
       </div>
       <img src="/logos/java.svg" alt="java logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Java</div>
-    </a>
+    </router-link>
 
-    <a :href="generateLink('/sdk/php/3/')" class="Tiles-item">
+    <router-link :to="{path: generateLink('/sdk/php/3/')}" class="Tiles-item">
       <img src="/logos/php.svg" alt="php logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">PHP</div>
-    </a>
-    <a :href="generateLink('/sdk/android/3/')" class="Tiles-item">
+    </router-link>
+    <router-link :to="{path: generateLink('/sdk/android/3/')}" class="Tiles-item">
       <img src="/logos/android.svg" alt="android logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Android</div>
-    </a>
+    </router-link>
     <a href="https://github.com/kuzzleio/sdk-ruby" class="Tiles-item">
       <div class="ribbon">
         <span>ALPHA</span>

--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -23,10 +23,10 @@
 
               <div v-for="item__2 in getPageChildren(item__1)">
                 <li class="md-nav__item">
-                  <a
+                  <router-link
                     class="md-nav__link"
                     :class="{'md-nav__link--active': $page.path === item__2.path, 'md-nav__item--code': item__2.frontmatter.code == true}"
-                    :href="getFirstValidChild(item__2).path"
+                    :to="{path: getFirstValidChild(item__2).path}"
                   >
                     <div v-if="getPageChildren(item__2).length">
                       <i
@@ -40,7 +40,7 @@
                     <div v-else>
                       <span class="no_arrow">{{item__2.title}}</span>
                     </div>
-                  </a>
+                  </router-link>
                 </li>
 
                 <ul
@@ -49,24 +49,24 @@
                 >
                   <div v-for="item__3 of getPageChildren(item__2)" class="md-nav__item">
                     <li v-if="$page.path === item__3.path">
-                      <a
+                      <router-link
                         class="md-nav__link--active"
                         :class="{'md-nav__item--code': item__3.frontmatter.code}"
-                        :href="`${item__3.path}`"
+                        :to="{path: item__3.path}"
                         :title="item__3.title"
                       >
                         <span class="no_arrow">{{item__3.title}}</span>
-                      </a>
+                      </router-link>
                     </li>
                     <li v-else>
-                      <a
-                        :href="`${item__3.path}`"
+                      <router-link
+                        :to="{path: item__3.path}"
                         :title="item__3.title"
                         class="md-nav__link"
                         :class="{'md-nav__item--code': item__3.frontmatter.code}"
                       >
                         <span class="no_arrow">{{item__3.title}}</span>
-                      </a>
+                      </router-link>
                     </li>
                   </div>
                 </ul>

--- a/src/.vuepress/theme/Tabs.vue
+++ b/src/.vuepress/theme/Tabs.vue
@@ -4,52 +4,52 @@
     <div class="md-tabs__inner md-grid">
       <ul class="md-tabs__list">
         <li class="md-tabs__item">
-          <a
+          <router-link
+            :to="{path: generateLink('/core/1/guides/')}"
             :class="{'md-tabs__link--active': $route.path.match('/guides/')}"
-            :href="generateLink('/core/1/guides/')"
             title="Guide"
             class="md-tabs__link"
-          >Guides</a>
+          >Guides</router-link>
         </li>
         <li class="md-tabs__item">
-          <a
+          <router-link
             :class="{'md-tabs__link--active': $route.path.match('/api/')}"
-            :href="generateLink('/core/1/api/')"
+            :to="{path: generateLink('/core/1/api/')}"
             title="API"
             class="md-tabs__link"
-          >API</a>
+          >API</router-link>
         </li>
         <li class="md-tabs__item">
-          <a
+          <router-link
             :class="{'md-tabs__link--active': $route.path.match('/sdk/')}"
-            href="/sdk/"
+            :to="{path: '/sdk/'}"
             title="SDK"
             class="md-tabs__link"
-          >SDK</a>
+          >SDK</router-link>
         </li>
         <li class="md-tabs__item">
-          <a
+          <router-link
             :class="{'md-tabs__link--active': $route.path.match('/plugins/')}"
-            :href="generateLink('/core/1/plugins/')"
+            :to="{path: generateLink('/core/1/plugins/')}"
             title="Plugins"
             class="md-tabs__link"
-          >Plugins</a>
+          >Plugins</router-link>
         </li>
         <li class="md-tabs__item">
-          <a
+          <router-link
             :class="{'md-tabs__link--active': $route.path.match('/protocols/')}"
-            :href="generateLink('/core/1/protocols/')"
+            :to="{path: generateLink('/core/1/protocols/')}"
             title="Protocols"
             class="md-tabs__link"
-          >Protocols</a>
+          >Protocols</router-link>
         </li>
         <li class="md-tabs__item">
-          <a
+          <router-link
             :class="{'md-tabs__link--active': $route.path.match('/koncorde/')}"
-            :href="generateLink('/core/1/koncorde/')"
+            :to="{path: generateLink('/core/1/koncorde/')}"
             title="Koncorde"
             class="md-tabs__link"
-          >Koncorde</a>
+          >Koncorde</router-link>
         </li>
       </ul>
     </div>

--- a/src/.vuepress/theme/TabsMobile.vue
+++ b/src/.vuepress/theme/TabsMobile.vue
@@ -4,45 +4,51 @@
       <SDKSelector :items="sdkList"/>
     </div>
 
-    <a
-      href="/guide"
+    <router-link
+      :to="{path: generateLink('/core/1/guides/')}"
       title="Guides"
       class="md-source"
       data-md-state="done"
       style="display:inline-block;"
     >
       <div class="md-source__repository">Guides</div>
-    </a>
-    <a
-      href="/sdk-reference"
+    </router-link>
+    <router-link
+      :to="{path:generateLink('/core/1/api/')}"
+      title="API"
+      class="md-source"
+      data-md-state="done"
+      style="display:inline-block;"
+    >
+      <div class="md-source__repository">API</div>
+    </router-link>
+    <router-link
+      :to="{path: '/sdk/'}"
       title="SDKs"
       class="md-source"
       data-md-state="done"
       style="display:inline-block;"
     >
       <div class="md-source__repository">SDK</div>
-    </a>
-    <a href="/api" title="API" class="md-source" data-md-state="done" style="display:inline-block;">
-      <div class="md-source__repository">API</div>
-    </a>
-    <a
-      href="/plugins"
+    </router-link>
+    <router-link
+      :to="{path: generateLink('/core/1/plugins/')}"
       title="Plugins"
       class="md-source"
       data-md-state="done"
       style="display:inline-block;"
     >
       <div class="md-source__repository">Plugins</div>
-    </a>
-    <a
-      href="/protocols"
+    </router-link>
+    <router-link
+      :to="{path: generateLink('/core/1/protocols/')}"
       title="Protocols"
       class="md-source"
       data-md-state="done"
       style="display:inline-block;"
     >
       <div class="md-source__repository">Protocols</div>
-    </a>
+    </router-link>
   </div>
 </template>
 

--- a/src/.vuepress/theme/TabsMobile.vue
+++ b/src/.vuepress/theme/TabsMobile.vue
@@ -14,7 +14,7 @@
       <div class="md-source__repository">Guides</div>
     </router-link>
     <router-link
-      :to="{path:generateLink('/core/1/api/')}"
+      :to="{path: generateLink('/core/1/api/')}"
       title="API"
       class="md-source"
       data-md-state="done"
@@ -53,12 +53,19 @@
 </template>
 
 <script>
+import { getValidLinkByRootPath } from '../util.js';
 import sdkList from '../sdk.json';
+
 export default {
   data() {
     return {
       sdkList
     };
+  },
+   methods: {
+    generateLink(path) {
+      return getValidLinkByRootPath(path, this.$site.pages);
+    }
   }
 };
 </script>

--- a/src/core/1/guides/essentials/installing-kuzzle/index.md
+++ b/src/core/1/guides/essentials/installing-kuzzle/index.md
@@ -127,7 +127,7 @@ Associated password is your unique instance ID. You can get it from the EC2 AWS 
 In this section we will perform a manual installation of Kuzzle on a Linux distribution. We choose Linux because all Kuzzle components work natively on it.
 
 ::: info
-By default, Kuzzle expects all the components to be running on localhost but you can [change](/core/1/guides/essentials/configuration/)'ll be able to select which <a :href="`${$site.base}core/1/guides/essentials/admin-console/#connect-to-kuzzle`">Kuzzle</a> installation that you want to manage. this behavior.
+By default, Kuzzle expects all the components to be running on localhost but you can [change](/core/1/guides/essentials/configuration/)'ll be able to select which [Kuzzle](/core/1/guides/essentials/admin-console/#connect-to-kuzzle) installation that you want to manage. this behavior.
 :::
 
 We will run Kuzzle using [pm2](http://pm2.keymetrics.io/), a process management tool used to monitor Node.js applications.

--- a/src/core/1/guides/essentials/real-time/index.md
+++ b/src/core/1/guides/essentials/real-time/index.md
@@ -47,7 +47,7 @@ Subscription to a room is done via the [realtime:subscribe](/core/1/api/controll
  - subscription filters contained in the `body` of the request.
 
 ::: info
-In order to use Kuzzle in Pub/Sub mode only, the index and collection do not need to physically exist in the database (e.g. created in Kuzzle via the <a href="/core/1/api/controllers/index/create">index:create</a> and <a href="/core/1/api/controllers/collection/create">collection:create</a> methods of the API).
+In order to use Kuzzle in Pub/Sub mode only, the index and collection do not need to physically exist in the database (e.g. created in Kuzzle via the [index:create](/core/1/api/controllers/index/create) and [collection:create](/core/1/api/controllers/collection/create) methods of the API).
 <br/>
 These information are only used to define an ephemeral room between several customers.
 :::
@@ -135,7 +135,7 @@ Customers subscribing to this channel will receive the following notification:
 More information about the [Document Notification format](/core/1/api/essentials/notifications/#documents-changes-messages)
 
 ::: warning
-Messages published with the <a href="/core/1/api/controllers/realtime/publish">realtime:publish</a> method are not persisted in the database.
+Messages published with the [realtime:publish](/core/1/api/controllers/realtime/publish) method are not persisted in the database.
 :::
 
 ## Database notifications

--- a/src/core/1/guides/essentials/security/index.md
+++ b/src/core/1/guides/essentials/security/index.md
@@ -210,4 +210,4 @@ There are multiple ways of adding a business logic layer on top of the standard 
 
 * With a [Pipe Plugin](/core/1/plugins/guides/pipes), you can listen to one or multiple [API events](/core/1/plugins/guides/events/), and decide whether you accept a query or document according to your business rules (you can see an example on [Github](https://github.com/kuzzleio/kuzzle-plugin-sample-custom-policies))
 * If all you need is to make sure that submitted documents follow a strict set of formatting rules, you can add [document validators](/core/1/guides/cookbooks/datavalidation/)
-* <DeprecatedBadge version="1.4.0" /> Using <a href="/core/1/guides/kuzzle-depth/roles-definitions">Permission Closures</a>, you can add functions directly into role definitions
+* <DeprecatedBadge version="1.4.0" /> Using [Permission Closures](/core/1/guides/kuzzle-depth/roles-definitions), you can add functions directly into role definitions

--- a/src/core/1/koncorde/essentials/operands/index.md
+++ b/src/core/1/koncorde/essentials/operands/index.md
@@ -15,7 +15,7 @@ all the available terms.
 
 <div class="alert alert-info">
 Note that the ability to combine multiple terms together allows to create different filters that have equivalent scope.
-Such filters are optimized by Koncorde, thus <a href="/core/1/koncorde/essentials/advanced#filter-equivalence-default">internally represented by the same ID</a>.
+Such filters are optimized by Koncorde, thus [internally represented by the same ID](/core/1/koncorde/essentials/advanced#filter-equivalence-default).
 </div>
 
 ## and

--- a/src/core/1/plugins/essentials/getting-started/index.md
+++ b/src/core/1/plugins/essentials/getting-started/index.md
@@ -40,7 +40,7 @@ The main Plugin class is defined in the `index.js`. You can start edit it adding
 We need to provide the `configuration` and the `context` to plugins. In that purpose, plugins must have an `init` function which will have them as parameters : this `init` function is the very first one to be called by Kuzzle and is mandatory to start a plugin. You can now write your own functions and your own routes as described inside the `index.js`. You can also write unit tests : see `steps.js`.
 
 <div class="alert alert-info">
-You can find more information about the <code>init</code> function <a href="/core/1/plugins/guides/manual-setup/init-function/"> here</a>.
+You can find more information about the <code>init</code> function [ here](/core/1/plugins/guides/manual-setup/init-function/).
 </div>
 <div class="alert alert-success">
 You have now everything you need to start writing your own Kuzzle plugin.

--- a/src/core/1/plugins/guides/events/api-events/index.md
+++ b/src/core/1/plugins/guides/events/api-events/index.md
@@ -21,7 +21,7 @@ All API actions, without exception, trigger two of these three events:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 A `before` event is triggered before an API request starts.
 
@@ -47,7 +47,7 @@ The `before` event name is built using the following template:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 An `after` event is triggered after an API request succeeds.
 
@@ -73,7 +73,7 @@ The `after` event name is built using the following template:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 An `error` event is triggered after an API request fails.
 

--- a/src/core/1/plugins/guides/events/http-delete/index.md
+++ b/src/core/1/plugins/guides/events/http-delete/index.md
@@ -10,6 +10,6 @@ title: http:delete
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP DELETE methods.

--- a/src/core/1/plugins/guides/events/http-get/index.md
+++ b/src/core/1/plugins/guides/events/http-get/index.md
@@ -10,6 +10,6 @@ title: http:get
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP GET methods.

--- a/src/core/1/plugins/guides/events/http-head/index.md
+++ b/src/core/1/plugins/guides/events/http-head/index.md
@@ -10,6 +10,6 @@ title: http:head
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP HEAD methods.

--- a/src/core/1/plugins/guides/events/http-options/index.md
+++ b/src/core/1/plugins/guides/events/http-options/index.md
@@ -10,6 +10,6 @@ title: http:options
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP OPTIONS methods.

--- a/src/core/1/plugins/guides/events/http-patch/index.md
+++ b/src/core/1/plugins/guides/events/http-patch/index.md
@@ -10,6 +10,6 @@ title: http:patch
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP PATCH methods.

--- a/src/core/1/plugins/guides/events/http-post/index.md
+++ b/src/core/1/plugins/guides/events/http-post/index.md
@@ -10,6 +10,6 @@ title: http:post
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP POST methods.

--- a/src/core/1/plugins/guides/events/http-put/index.md
+++ b/src/core/1/plugins/guides/events/http-put/index.md
@@ -10,6 +10,6 @@ title: http:put
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request has been submitted through HTTP PUT methods.

--- a/src/core/1/plugins/guides/events/notify-dispatch/index.md
+++ b/src/core/1/plugins/guides/events/notify-dispatch/index.md
@@ -10,7 +10,7 @@ title: notify:dispatch
 
 | Arguments | Type                                                                     | Description                           |
 | --------- | ------------------------------------------------------------------------ | ------------------------------------- |
-| `message` | <pre><a href=/core/1/api/essentials/notifications>Notification</a></pre> | The normalized real-time notification |
+| `message` | [`Notification`](/core/1/api/essentials/notifications) | The normalized real-time notification |
 
 Triggered whenever a real-time notification is about to be sent.
 

--- a/src/core/1/plugins/guides/events/notify-document/index.md
+++ b/src/core/1/plugins/guides/events/notify-document/index.md
@@ -10,7 +10,7 @@ title: notify:document
 
 | Arguments | Type                                                                      | Description                           |
 | --------- | ------------------------------------------------------------------------- | ------------------------------------- |
-| `message` | <pre><a href=/core/1/api/essentials/notifications/>Notification</a></pre> | The normalized real-time notification |
+| `message` | [`Notification`](/core/1/api/essentials/notifications/) | The normalized real-time notification |
 
 Triggered whenever a real-time document notification is about to be sent.
 

--- a/src/core/1/plugins/guides/events/notify-server/index.md
+++ b/src/core/1/plugins/guides/events/notify-server/index.md
@@ -10,7 +10,7 @@ title: notify:server
 
 | Arguments | Type                                                                      | Description                           |
 | --------- | ------------------------------------------------------------------------- | ------------------------------------- |
-| `message` | <pre><a href=/core/1/api/essentials/notifications/>Notification</a></pre> | The normalized real-time notification |
+| `message` | [`Notification`](/core/1/api/essentials/notifications/) | The normalized real-time notification |
 
 Triggered whenever a real-time server notification is about to be sent.
 

--- a/src/core/1/plugins/guides/events/notify-user/index.md
+++ b/src/core/1/plugins/guides/events/notify-user/index.md
@@ -10,7 +10,7 @@ title: notify:user
 
 | Arguments | Type                                                                      | Description                           |
 | --------- | ------------------------------------------------------------------------- | ------------------------------------- |
-| `message` | <pre><a href=/core/1/api/essentials/notifications/>Notification</a></pre> | The normalized real-time notification |
+| `message` | [`Notification`](/core/1/api/essentials/notifications/) | The normalized real-time notification |
 
 Triggered whenever a real-time user notification is about to be sent.
 

--- a/src/core/1/plugins/guides/events/plugin-events/index.md
+++ b/src/core/1/plugins/guides/events/plugin-events/index.md
@@ -24,7 +24,7 @@ All calls to plugins API actions trigger two of these three events:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 A `before` event is triggered before a plugin API request starts.
 
@@ -50,7 +50,7 @@ The `before` event name is built using the following template:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 An `after` event is triggered after a plugin API request succeeds.
 
@@ -76,7 +76,7 @@ The `after` event name is built using the following template:
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 An `error` event is triggered after a plugin API request fails.
 

--- a/src/core/1/plugins/guides/events/request-on-authorized/index.md
+++ b/src/core/1/plugins/guides/events/request-on-authorized/index.md
@@ -10,7 +10,7 @@ title: request:onAuthorized
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request passes authorization checks and is ready to be processed.
 

--- a/src/core/1/plugins/guides/events/request-on-error/index.md
+++ b/src/core/1/plugins/guides/events/request-on-error/index.md
@@ -10,7 +10,7 @@ title: request:onError
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request execution fails.
 

--- a/src/core/1/plugins/guides/events/request-on-success/index.md
+++ b/src/core/1/plugins/guides/events/request-on-success/index.md
@@ -10,7 +10,7 @@ title: request:onSuccess
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request execution succeeds.
 

--- a/src/core/1/plugins/guides/events/request-on-unauthorized/index.md
+++ b/src/core/1/plugins/guides/events/request-on-unauthorized/index.md
@@ -10,6 +10,6 @@ title: request:onUnauthorized
 
 | Arguments | Type                                                           | Description                |
 | --------- | -------------------------------------------------------------- | -------------------------- |
-| `request` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The normalized API request |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | The normalized API request |
 
 Triggered whenever a request fails authorization checks, and is about to be rejected with a `401` error code.

--- a/src/core/1/plugins/guides/pipes/index.md
+++ b/src/core/1/plugins/guides/pipes/index.md
@@ -14,7 +14,7 @@ Pipes can:
 - Decide to abort a task. If a pipe throws an error, Kuzzle interrupts the task, and forwards a standardized version of the thrown error to the originating user
 - Change the received information. Kuzzle will use the updated information upon resuming the task
 
-<div class="alert alert-warning">If a pipe takes too long to respond, Kuzzle will eventually abort the entire task with a <a href="/core/1/plugins/plugin-context/errors/gatewaytimeouterror">GatewayTimeout</a> error. The timeout value can be changed in the <a href="/core/1/guides/essentials/configuration/">configuration files.</a></div>
+<div class="alert alert-warning">If a pipe takes too long to respond, Kuzzle will eventually abort the entire task with a [GatewayTimeout](/core/1/plugins/plugin-context/errors/gatewaytimeouterror) error. The timeout value can be changed in the [configuration files.](/core/1/guides/essentials/configuration/)</div>
 
 ---
 
@@ -36,7 +36,7 @@ Pipes must notify Kuzzle about their completion by one of these two means:
 - by calling the `callback(error, request)` function received as their last argument (leave the `error` null if the pipe executed successfully)
 - by returning a promise, resolved (or rejected) with a valid [Request](/core/1/guides/essentials/request-and-response-format/) upon the completion of the pipe
 
-<div class="alert alert-warning">You must either call the callback with a valid <a href="/core/1/guides/essentials/request-and-response-format/">Request</a> or return a promise resolving to one.</div>
+<div class="alert alert-warning">You must either call the callback with a valid [Request](/core/1/guides/essentials/request-and-response-format/) or return a promise resolving to one.</div>
 
 If a pipe throws an error, it is advised to throw one of the available [KuzzleError](/core/1/plugins/plugin-context/errors/kuzzleerror) object. Otherwise, Kuzzle will reject the task with a `PluginImplementationError` error.
 

--- a/src/core/1/plugins/guides/strategies/auth-functions/index.md
+++ b/src/core/1/plugins/guides/strategies/auth-functions/index.md
@@ -43,7 +43,7 @@ create(request, credentials, kuid, strategy);
 
 | Arguments     | Type                                                           | Description                                                                                      |
 | ------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `request`     | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | API request asking for the credentials creation                                                  |
+| `request`     | [`Request`](/core/1/plugins/constructors/request) | API request asking for the credentials creation                                                  |
 | `credentials` | <pre>object</pre>                                              | New credentials to create, already validated by this strategy's [validate](#validate) function   |
 | `kuid`        | <pre>string</pre>                                              | User's [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) |
 | `strategy`    | <pre>string</pre>                                              | Authentication strategy used by these credentials                                                |
@@ -70,7 +70,7 @@ delete (request, kuid, strategy);
 
 | Arguments  | Type                                                           | Description                                                                                      |
 | ---------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `request`  | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | API request asking for the credentials deletion                                                  |
+| `request`  | [`Request`](/core/1/plugins/constructors/request) | API request asking for the credentials deletion                                                  |
 | `kuid`     | <pre>string</pre>                                              | User's [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) |
 | `strategy` | <pre>string</pre>                                              | Authentication strategy name                                                                     |
 
@@ -94,7 +94,7 @@ exists(request, kuid, strategy);
 
 | Arguments  | Type                                                           | Description                                                                                      |
 | ---------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `request`  | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | Source API request                                                                               |
+| `request`  | [`Request`](/core/1/plugins/constructors/request) | Source API request                                                                               |
 | `kuid`     | <pre>string</pre>                                              | User's [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) |
 | `strategy` | <pre>string</pre>                                              | Authentication strategy name                                                                     |
 
@@ -118,7 +118,7 @@ update(request, credentials, kuid, strategy);
 
 | Arguments     | Type                                                           | Description                                                                                            |
 | ------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `request`     | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | Source API request                                                                                     |
+| `request`     | [`Request`](/core/1/plugins/constructors/request) | Source API request                                                                                     |
 | `credentials` | <pre>object</pre>                                              | Updated credentials.<br/>Those are already validated by this strategy's [validate](#validate) function |
 | `kuid`        | <pre>string</pre>                                              | User's [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid)       |
 | `strategy`    | <pre>string</pre>                                              | Authentication strategy name                                                                           |
@@ -145,7 +145,7 @@ validate(request, credentials, kuid, strategy, isUpdate);
 
 | Arguments     | Type                                                           | Description                                                                                                                                                                                 |
 | ------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `request`     | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | Source API request                                                                                                                                                                          |
+| `request`     | [`Request`](/core/1/plugins/constructors/request) | Source API request                                                                                                                                                                          |
 | `credentials` | <pre>object</pre>                                              | Credentials to validate                                                                                                                                                                     |
 | `kuid`        | <pre>string</pre>                                              | User's [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid)                                                                                            |
 | `strategy`    | <pre>string</pre>                                              | Authentication strategy name                                                                                                                                                                |
@@ -185,7 +185,7 @@ The `payload` object has the following properties:
 
 | Properties | Type                                                           | Description                                                                     |
 | ---------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `original` | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | Source API login request                                                        |
+| `original` | [`Request`](/core/1/plugins/constructors/request) | Source API login request                                                        |
 | `query`    | <pre>object</pre>                                              | Direct link to `original.input.args`, containing the optional request arguments |
 | `body`     | <pre>object</pre>                                              | Direct link to `original.input.body`, containing the request body content       |
 
@@ -240,7 +240,7 @@ getById(request, id, strategy);
 
 | Arguments  | Type                                                           | Description                                        |
 | ---------- | -------------------------------------------------------------- | -------------------------------------------------- |
-| `request`  | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The API request asking for credentials information |
+| `request`  | [`Request`](/core/1/plugins/constructors/request) | The API request asking for credentials information |
 | `id`       | <pre>string</pre>                                              | Strategy's user identifier                         |
 | `strategy` | <pre>string</pre>                                              | Authentication strategy name                       |
 
@@ -268,7 +268,7 @@ getInfo(request, kuid, strategy);
 
 | Arguments  | Type                                                           | Description                                                                                      |
 | ---------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `request`  | <pre><a href=/core/1/plugins/constructors/request>Request</a></pre> | The API request asking for credentials information                                               |
+| `request`  | [`Request`](/core/1/plugins/constructors/request) | The API request asking for credentials information                                               |
 | `kuid`     | <pre>string</pre>                                              | User's [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) |
 | `strategy` | <pre>string</pre>                                              | Authentication strategy name                                                                     |
 

--- a/src/core/1/plugins/plugin-context/accessors/execute/index.md
+++ b/src/core/1/plugins/plugin-context/accessors/execute/index.md
@@ -22,7 +22,7 @@ execute(request, [callback]);
 
 | Arguments  | Type                                                           | Description                                    |
 | ---------- | -------------------------------------------------------------- | ---------------------------------------------- |
-| `request`  | <a href=/core/1/plugins/constructors/request><pre>Request</pre></a> | The API query to execute                       |
+| `request`  | [`Request`](/core/1/plugins/constructors/request) | The API query to execute                       |
 | `callback` | <pre>function</pre>                                            | Callback to call with the API execution result |
 
 ---

--- a/src/core/1/plugins/plugin-context/accessors/validation/index.md
+++ b/src/core/1/plugins/plugin-context/accessors/validation/index.md
@@ -46,7 +46,7 @@ validate(request, [verbose]);
 
 | Arguments | Type                                                           | Description                                                                                         |
 | --------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `request` | <a href=/core/1/plugins/constructors/request><pre>Request</pre></a> | Request object with a non-empty body content                                                        |
+| `request` | [`Request`](/core/1/plugins/constructors/request) | Request object with a non-empty body content                                                        |
 | `verbose` | <pre>boolean</pre>                                             | If true, returns an exhaustive validation report, instead of failing at the first error encountered |
 
 ### Return

--- a/src/core/1/plugins/plugin-context/constructors/request/index.md
+++ b/src/core/1/plugins/plugin-context/constructors/request/index.md
@@ -58,7 +58,7 @@ The `options` argument accepts the following parameters:
 | -------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `connection`   | <pre>object</pre>                                           | <SinceBadge version="1.4.1" /> Connection information (see the <a href=https://github.com/kuzzleio/kuzzle-common-objects/blob/master/README.md#requestcontextconnection-object-format>connection</a> object documentation) |
 | `connectionId` | <pre>string</pre>                                           | <DeprecatedBadge version="1.4.1" /> Connection unique identifier                                                                                                                                                           |
-| `error`        | <pre><a href=/core/1/plugins/errors>KuzzleError</a>, Error</pre> | Sets the request response with the provided error                                                                                                                                                                          |
+| `error`        | [`KuzzleError`](/core/1/plugins/errors), Error</pre> | Sets the request response with the provided error                                                                                                                                                                          |
 | `requestId`    | <pre>string</pre>                                           | User-defined request identifier                                                                                                                                                                                            |
 | `result`       | <pre>\*</pre>                                               | Sets the request response with the provided result, and the request status is set to `200`                                                                                                                                 |
 | `status`       | <pre>integer</pre>                                          | Request status, following the [HTTP error code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) standard                                                                                                          |
@@ -72,7 +72,7 @@ Read-only:
 | Property    | Type                                                                                                                               | Description                                                           |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | `context`   | <pre><a href=https://github.com/kuzzleio/kuzzle-common-objects/blob/master/README.md#modelsrequestcontext>RequestContext</a></pre> | General request information (logged user, network information, ...)   |
-| `error`     | <pre><a href=/core/1/plugins/errors>KuzzleError</a></pre>                                                                               | Request error                                                         |
+| `error`     | [`KuzzleError`](/core/1/plugins/errors)                                                                               | Request error                                                         |
 | `input`     | <pre><a href=https://github.com/kuzzleio/kuzzle-common-objects/blob/master/README.md#modelsrequestinput>RequestInput</a></pre>     | Input request representation                                          |
 | `response`  | <pre><a href=https://github.com/kuzzleio/kuzzle-common-objects#requestresponse>RequestResponse</a></pre>                           | Serialized [request response](/core/1/api/essentials/kuzzle-response) |
 | `result`    | <pre>\*</pre>                                                                                                                      | Request result                                                        |
@@ -128,7 +128,7 @@ setError(error);
 
 | Arguments | Type                                                 | Description   |
 | --------- | ---------------------------------------------------- | ------------- |
-| `error`   | <pre><a href=/core/1/plugins/errors>KuzzleError</a></pre> | Request error |
+| `error`   | [`KuzzleError`](/core/1/plugins/errors) | Request error |
 
 If a `KuzzleError` object is provided, the request's status attribute is set to the error one.
 

--- a/src/core/1/plugins/plugin-context/errors/partialerror/index.md
+++ b/src/core/1/plugins/plugin-context/errors/partialerror/index.md
@@ -21,7 +21,7 @@ new context.error.PartialError(message, failures);
 | Arguments  | Type                                                               | Description                |
 | ---------- | ------------------------------------------------------------------ | -------------------------- |
 | `message`  | <pre>string</pre>                                                  | Error message              |
-| `failures` | <pre><a href=/core/1/plugins/errors/kuzzleerror>KuzzleError[]</a></pre> | List of encountered errors |
+| `failures` | [`KuzzleError[]`](/core/1/plugins/errors/kuzzleerror) | List of encountered errors |
 
 ## Status Code
 

--- a/src/core/1/protocols/api/context/errors/index.md
+++ b/src/core/1/protocols/api/context/errors/index.md
@@ -171,7 +171,7 @@ new context.error.PartialError(message, errors);
 | Arguments  | Type                                                                                       | Description                |
 | ---------- | ------------------------------------------------------------------------------------------ | -------------------------- |
 | `message`  | <pre>string</pre>                                                                          | Error message              |
-| `failures` | <pre><a href=/core/1/protocols/api/context/errors/#kuzzleerror-default>KuzzleError[]</a></pre> | List of encountered errors |
+| `failures` | [`KuzzleError[]`](/core/1/protocols/api/context/errors/#kuzzleerror-default) | List of encountered errors |
 
 ### Status Code
 

--- a/src/core/1/protocols/api/context/request/index.md
+++ b/src/core/1/protocols/api/context/request/index.md
@@ -45,7 +45,7 @@ The `options` object can contain the following properties:
 | -------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `connection`   | `object`                                                              | <SinceBadge version="1.4.1" /> Connection information (see the <a href=https://github.com/kuzzleio/kuzzle-common-objects/blob/master/README.md#requestcontextconnection-object-format>connection</a> object documentation) |
 | `connectionId` | `string`                                                              | <DeprecatedBadge version="1.4.1" /> Connection unique identifier                                                                                                                                                           |
-| `error`        | <a href=/core/1/protocols/api/context/errors>KuzzleError</a>,<br/>Error | Sets the request response with the provided error                                                                                                                                                                          |
+| `error`        | [`KuzzleError`](/core/1/protocols/api/context/errors),<br/>Error | Sets the request response with the provided error                                                                                                                                                                          |
 | `requestId`    | `string`                                                              | User-defined request identifier                                                                                                                                                                                            |
 | `result`       | `*`                                                                  | Sets the request response with the provided result, and the request status is set to `200`                                                                                                                                 |
 | `status`       | `integer`                                                             | Request status, following the [HTTP error code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) standard                                                                                                          |
@@ -59,7 +59,7 @@ Read-only:
 | Properties  | Type                                                                                                                      | Description                                                           |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | `context`   | `<a href=https://github.com/kuzzleio/kuzzle-common-objects/blob/master/README.md#modelsrequestcontext>RequestContext</a>` | General request information (logged user, network information, ...)   |
-| `error`     | `<a href=/core/1/protocols/api/context/errors>KuzzleError</a> | Request error                                                 |
+| `error`     | `[`KuzzleError`](/core/1/protocols/api/context/errors) | Request error                                                 |
 | `input`     | `<a href=https://github.com/kuzzleio/kuzzle-common-objects/blob/master/README.md#modelsrequestinput>RequestInput</a>`     | Input request representation                                          |
 | `response`  | `<a href=https://github.com/kuzzleio/kuzzle-common-objects#requestresponse>RequestResponse</a>`                           | Serialized [request response](/core/1/api/essentials/kuzzle-response) |
 | `result`    | `*`                                                                                                                      | Request result                                                        |
@@ -115,7 +115,7 @@ setError(error);
 
 | Arguments | Type                                                              | Description   |
 | --------- | ----------------------------------------------------------------- | ------------- |
-| `error`   | `<a href=/core/1/protocols/api/context/errors>KuzzleError</a>, Error` | Request error |
+| `error`   | `[`KuzzleError`](/core/1/protocols/api/context/errors), Error` | Request error |
 
 If a `KuzzleError` object is provided, the request's status attribute is set to the error one.
 

--- a/src/core/1/protocols/api/context/requestcontext/index.md
+++ b/src/core/1/protocols/api/context/requestcontext/index.md
@@ -32,7 +32,7 @@ The `options` object can contain the following properties:
 
 | Properties   | Type                                                                               | Description                      |
 | ------------ | ---------------------------------------------------------------------------------- | -------------------------------- |
-| `connection` | <pre><a href=/core/1/protocols/api/context/clientconnection>ClientConnection</a></pre> | Connection information           |
+| `connection` | [`ClientConnection`](/core/1/protocols/api/context/clientconnection) | Connection information           |
 | `token`      | <pre>string</pre>                                                                  | Authorization token              |
 | `user`       | <pre>object</pre>                                                                  | Kuzzle internal user information |
 
@@ -42,6 +42,6 @@ The `options` object can contain the following properties:
 
 | Properties   | Type                                                                               | Description                      |
 | ------------ | ---------------------------------------------------------------------------------- | -------------------------------- |
-| `connection` | <pre><a href=/core/1/protocols/api/context/clientconnection>ClientConnection</a></pre> | Connection information           |
+| `connection` | [`ClientConnection`](/core/1/protocols/api/context/clientconnection) | Connection information           |
 | `token`      | <pre>string</pre>                                                                  | Authorization token              |
 | `user`       | <pre>object</pre>                                                                  | Kuzzle internal user information |

--- a/src/core/1/protocols/api/entrypoint/execute/index.md
+++ b/src/core/1/protocols/api/entrypoint/execute/index.md
@@ -24,7 +24,7 @@ execute(request, [callback]);
 
 | Arguments  | Type                                                             | Description                                                                                              |
 | ---------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `request`  | <pre><a href=/core/1/protocols/api/context/request>Request</a></pre> | The API query to execute                                                                                 |
+| `request`  | [`Request`](/core/1/protocols/api/context/request) | The API query to execute                                                                                 |
 | `callback` | <pre>function</pre>                                              | Callback to call with the API execution result.<br/>If not provided, `execute` returns a promise instead |
 
 ---

--- a/src/core/1/protocols/api/entrypoint/newconnection/index.md
+++ b/src/core/1/protocols/api/entrypoint/newconnection/index.md
@@ -22,7 +22,7 @@ newConnection(connection);
 
 | Arguments    | Type                                                                               | Description         |
 | ------------ | ---------------------------------------------------------------------------------- | ------------------- |
-| `connection` | <pre><a href=/core/1/protocols/api/context/clientconnection>ClientConnection</a></pre> | New user connection |
+| `connection` | [`ClientConnection`](/core/1/protocols/api/context/clientconnection) | New user connection |
 
 ---
 

--- a/src/core/1/protocols/api/methods/init/index.md
+++ b/src/core/1/protocols/api/methods/init/index.md
@@ -22,8 +22,8 @@ init(entryPoint, context);
 
 | Arguments    | Type                                                           | Description                                                                              |
 | ------------ | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `entryPoint` | <pre><a href=/core/1/protocols/api/entrypoint>EntryPoint</a></pre> | Provides an interface to protocol related methods                                        |
-| `context`    | <pre><a href=/core/1/protocols/api/context/>context</a></pre>       | Generic interface exposing objects and methods not directly related to the network layer |
+| `entryPoint` | [`EntryPoint`](/core/1/protocols/api/entrypoint) | Provides an interface to protocol related methods                                        |
+| `context`    | [`context`](/core/1/protocols/api/context/)       | Generic interface exposing objects and methods not directly related to the network layer |
 
 ---
 

--- a/src/sdk/android/3/core-classes/collection/scroll/index.md
+++ b/src/sdk/android/3/core-classes/collection/scroll/index.md
@@ -15,7 +15,7 @@ There is a small delay between the time a document is created and its availabili
 </div>
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/collection/search/index.md
+++ b/src/sdk/android/3/core-classes/collection/search/index.md
@@ -45,7 +45,7 @@ See [`SearchResult.fetchNext`](/sdk/android/3/core-classes/search-result/fetch-n
 | `size`     | number  | Provide the maximum number of results of the request (used to paginate results)                                                                                                                                   | `10`        |
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/kuzzle/login/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/login/index.md
@@ -19,7 +19,7 @@ If the login attempt fails, the `loginAttempt` event is fired with the following
 `{ success: false, error: 'error message' }`
 
 <div class="alert alert-info">
-This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. <a href="/core/1/guides/essentials/user-authentication/#local-strategy">Learn more.</a>
+This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. [Learn more.](/core/1/guides/essentials/user-authentication/#local-strategy)
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/kuzzle/query/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/query/index.md
@@ -11,7 +11,7 @@ Base method used to send queries to Kuzzle, following the [API Documentation](/c
 
 <div class="alert alert-warning">
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.<br/>
-Refer to Kuzzle's API Reference <a href="/core/1/api">here</a>
+Refer to Kuzzle's API Reference [here](/core/1/api)
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/memory-storage/sort/index.md
+++ b/src/sdk/android/3/core-classes/memory-storage/sort/index.md
@@ -11,7 +11,7 @@ Sorts and returns elements contained in a list, a set of unique values or a sort
 By default, sorting is numeric and elements are compared by their value interpreted as double precision floating point number.
 
 <div class="alert alert-info"
-While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the <a href="/sdk/android/3/core-classes/kuzzle/query">query method</a>
+While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the [query method](/sdk/android/3/core-classes/kuzzle/query)
 </div>
 
 [[_Redis documentation_]](https://redis.io/commands/sort)

--- a/src/sdk/android/3/core-classes/profile/add-policy/index.md
+++ b/src/sdk/android/3/core-classes/profile/add-policy/index.md
@@ -10,7 +10,7 @@ description: Profile:addPolicy
 Adds a role to the security profile.
 
 <div class="alert alert-info">
-Updating a security profile will have no impact until the <a href="/sdk/android/3/core-classes/profile/save/">save</a> method is called
+Updating a security profile will have no impact until the [save](/sdk/android/3/core-classes/profile/save/) method is called
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/role/set-content/index.md
+++ b/src/sdk/android/3/core-classes/role/set-content/index.md
@@ -10,7 +10,7 @@ description: Role:setContent
 Replaces the content of the `Role` object.
 
 <div class="alert alert-info">
-Updating a role content will have no impact until the <a href="/sdk/android/3/core-classes/role/save/">save</a> method is called
+Updating a role content will have no impact until the [save](/sdk/android/3/core-classes/role/save/) method is called
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/role/update/index.md
+++ b/src/sdk/android/3/core-classes/role/update/index.md
@@ -15,7 +15,7 @@ Updates the role object in Kuzzle.
     In other words, you always need to provide the complete role definition in the <code>updateContent</code> object.
   </p>
   <p>
-    This method has the same effect as calling <a href="/sdk/android/3/core-classes/role/set-content/"><code>setContent</code></a> followed by the <a href="/sdk/android/3/core-classes/role/save/"><code>save</code></a> method.
+    This method has the same effect as calling [`setContent`](/sdk/android/3/core-classes/role/set-content/) followed by the [`save`](/sdk/android/3/core-classes/role/save/) method.
   </p>
 </div>
 

--- a/src/sdk/android/3/core-classes/security/is-action-allowed/index.md
+++ b/src/sdk/android/3/core-classes/security/is-action-allowed/index.md
@@ -16,7 +16,7 @@ Specifies if an action is allowed, denied or conditional based on the rights pro
 An action is defined as a pair of action and controller (mandatory), plus an index and a collection(optional).
 
 <div class="alert alert-info">
-You can get the rights from Kuzzle by using <a href="/sdk/android/3/core-classes/security/get-user-rights/">`Security.getUserRights`</a> and <a href="/sdk/android/3/core-classes/kuzzle/get-my-rights">`Kuzzle.getMyRights`</a>.
+You can get the rights from Kuzzle by using [`Security.getUserRights`](/sdk/android/3/core-classes/security/get-user-rights/) and [`Kuzzle.getMyRights`](/sdk/android/3/core-classes/kuzzle/get-my-rights).
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/security/search-users/index.md
+++ b/src/sdk/android/3/core-classes/security/search-users/index.md
@@ -31,7 +31,7 @@ Return users matching the given filter.
 | `size`     | number  |  Number of hits to return per result page                                                                                                                                                                         | `10`        |
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/user/add-profile/index.md
+++ b/src/sdk/android/3/core-classes/user/add-profile/index.md
@@ -10,7 +10,7 @@ description: User:addProfile
 Replaces the security profile associated with the user.
 
 <div class="alert alert-info">
-Updating a user will have no impact until the <a href="/sdk/android/3/core-classes/user/create/"><code>create</code></a> or <a href="/sdk/android/3/core-classes/user/replace/"><code>replace</code></a> method is called
+Updating a user will have no impact until the [`create`](/sdk/android/3/core-classes/user/create/) or [`replace`](/sdk/android/3/core-classes/user/replace/) method is called
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/user/set-content/index.md
+++ b/src/sdk/android/3/core-classes/user/set-content/index.md
@@ -10,7 +10,7 @@ description: User:setContent
 Replaces the content of User.
 
 <div class="alert alert-info">
-Updating a user will have no impact until the <a href="/sdk/android/3/core-classes/user/create/"><code>create</code></a> or <a href="/sdk/android/3/core-classes/user/replace/"><code>replace</code></a> method is called
+Updating a user will have no impact until the [`create`](/sdk/android/3/core-classes/user/create/) or [`replace`](/sdk/android/3/core-classes/user/replace/) method is called
 </div>
 
 ---

--- a/src/sdk/android/3/core-classes/user/set-credentials/index.md
+++ b/src/sdk/android/3/core-classes/user/set-credentials/index.md
@@ -10,7 +10,7 @@ description: User:setCredentials
 Sets the user's credentials.
 
 <div class="alert alert-info">
-  Updating user credentials will have no impact until the <a href="/sdk/android/3/core-classes/user/create/"><code>create</code></a> method is called.<br />
+  Updating user credentials will have no impact until the [`create`](/sdk/android/3/core-classes/user/create/) method is called.<br />
   The credentials to send depend on the authentication plugin and the strategy you want to create credentials for.
 </div>
 ---

--- a/src/sdk/cpp/1/controllers/auth/login/index.md
+++ b/src/sdk/cpp/1/controllers/auth/login/index.md
@@ -42,7 +42,7 @@ Check the appropriate [authentication plugin](/core/1/plugins/guides/strategies/
 
 ### expiresIn
 
-The default value for the `expiresIn` option is defined at server level, in Kuzzle's [configuration file](/guide/1/essentials/configuration).
+The default value for the `expiresIn` option is defined at server level, in Kuzzle's [configuration file](/core/1/guides/essentials/configuration).
 
 
 ## Return

--- a/src/sdk/cpp/1/controllers/auth/login/index.md
+++ b/src/sdk/cpp/1/controllers/auth/login/index.md
@@ -42,7 +42,7 @@ Check the appropriate [authentication plugin](/core/1/plugins/guides/strategies/
 
 ### expiresIn
 
-The default value for the `expiresIn` option is defined at server level, in Kuzzle's [configuration file]({{ site_base_map }}guide/1/essentials/configuration).
+The default value for the `expiresIn` option is defined at server level, in Kuzzle's [configuration file](/guide/1/essentials/configuration).
 
 
 ## Return

--- a/src/sdk/cpp/1/core-classes/kuzzle/constructor/index.md
+++ b/src/sdk/cpp/1/core-classes/kuzzle/constructor/index.md
@@ -23,7 +23,7 @@ kuzzleio::Kuzzle(kuzzleio::Protocol* protocol, const options& options);
 
 | Argument   | Type                                                                   | Description                       |
 | ---------- | ---------------------------------------------------------------------- | --------------------------------- |
-| `protocol` | <pre><a href=/sdk/cpp/1/virtual-classes/protocol/>Protocol\*</a></pre> | Protocol used by the SDK instance |
+| `protocol` | [`Protocol\*`](/sdk/cpp/1/virtual-classes/protocol/) | Protocol used by the SDK instance |
 | `options`  | <pre>const kuzzleio::options\&</pre>                                   | Kuzzle object configuration       |
 
 ### protocol

--- a/src/sdk/cpp/1/essentials/getting-started/index.md
+++ b/src/sdk/cpp/1/essentials/getting-started/index.md
@@ -21,7 +21,7 @@ You will learn :
 Before proceeding, please make sure your system meets the following requirements :
 
 - A C++ compiler that supports C++ 11 sush as: **gcc** version 4.5 or higher
-- A running instance of Kuzzle Server (<a href="/core/1/guides/essentials/installing-kuzzle/">Kuzzle installation guide</a>)
+- A running instance of Kuzzle Server ([Kuzzle installation guide](/core/1/guides/essentials/installing-kuzzle/))
 
 </div>
 
@@ -145,6 +145,6 @@ Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzz
 Now that you're more familiar with the Go SDK, you can dive even deeper to learn how to leverage its full capabilities:
 
 - discover what this SDK has to offer by browsing other sections of this documentation
-- learn how to use <a href="/core/1/koncorde">Koncorde</a> to create incredibly fine-grained and blazing-fast subscriptions
-- follow our guide to learn how to perform <a href="/core/1/guides/essentials/user-authentication/#local-strategy">basic authentication</a>
-- follow our guide to learn how to <a href="/core/1/guides/essentials/security/">manage users and how to set up fine-grained access control</a>
+- learn how to use [Koncorde](/core/1/koncorde) to create incredibly fine-grained and blazing-fast subscriptions
+- follow our guide to learn how to perform [basic authentication](/core/1/guides/essentials/user-authentication/#local-strategy)
+- follow our guide to learn how to [manage users and how to set up fine-grained access control](/core/1/guides/essentials/security/)

--- a/src/sdk/java/1/controllers/realtime/subscribe/index.md
+++ b/src/sdk/java/1/controllers/realtime/subscribe/index.md
@@ -34,7 +34,7 @@ public String subscribe(
 | `index`      | <pre>String</pre>                                                                                          | Index name                                                                                         |
 | `collection` | <pre>String</pre>                                                                                          | Collection name                                                                                    |
 | `filters`    | <pre>String</pre>                                                                                          | JSON string representing a set of filters following [Koncorde syntax](/core/1/koncorde/essentials) |
-| `listener`   | <pre><a href="/sdk/java/1/essentials/realtime-notifications/">io.kuzzle.sdk.NotificationListener</a></pre> | Listener function to handle notifications                                                          |
+| `listener`   | <pre>[io.kuzzle.sdk.NotificationListener](/sdk/java/1/essentials/realtime-notifications/)</pre> | Listener function to handle notifications                                                          |
 | `options`    | <pre>io.kuzzle.sdk.RoomOptions</pre>                                                                       | Subscription options                                                                               |
 
 ### options

--- a/src/sdk/js/5/core-classes/collection/scroll/index.md
+++ b/src/sdk/js/5/core-classes/collection/scroll/index.md
@@ -15,7 +15,7 @@ There is a small delay between the time a document is created and its availabili
 </div>
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/collection/search/index.md
+++ b/src/sdk/js/5/core-classes/collection/search/index.md
@@ -45,7 +45,7 @@ See [`SearchResult.fetchNext`](/sdk/js/5/core-classes/search-result/fetch-next/#
 | `size`     | number  | Provide the maximum number of results of the request (used to paginate results)                                                                                                                                   | `10`        |
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/kuzzle/login/index.md
+++ b/src/sdk/js/5/core-classes/kuzzle/login/index.md
@@ -19,7 +19,7 @@ If the login attempt fails, the `loginAttempt` event is fired with the following
 `{ success: false, error: 'error message' }`
 
 <div class="alert alert-info">
-This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. <a href="/core/1/guides/essentials/user-authentication/#local-strategy">Learn more.</a>
+This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. [Learn more.](/core/1/guides/essentials/user-authentication/#local-strategy)
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/kuzzle/query/index.md
+++ b/src/sdk/js/5/core-classes/kuzzle/query/index.md
@@ -11,7 +11,7 @@ Base method used to send queries to Kuzzle, following the [API Documentation](/c
 
 <div class="alert alert-warning">
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.<br/>
-Refer to Kuzzle's API Reference <a href="/core/1/api">here</a>
+Refer to Kuzzle's API Reference [here](/core/1/api)
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/memory-storage/sort/index.md
+++ b/src/sdk/js/5/core-classes/memory-storage/sort/index.md
@@ -11,7 +11,7 @@ Sorts and returns elements contained in a list, a set of unique values or a sort
 By default, sorting is numeric and elements are compared by their value interpreted as double precision floating point number.
 
 <div class="alert alert-info">
-While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the <a href="/sdk/js/5/core-classes/kuzzle/query">query method</a>
+While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the [query method](/sdk/js/5/core-classes/kuzzle/query)
 </div>
 
 [[_Redis documentation_]](https://redis.io/commands/sort)

--- a/src/sdk/js/5/core-classes/profile/add-policy/index.md
+++ b/src/sdk/js/5/core-classes/profile/add-policy/index.md
@@ -10,7 +10,7 @@ description: Profile:addPolicy
 Adds a role to the security profile.
 
 <div class="alert alert-info">
-Updating a security profile will have no impact until the <a href="/sdk/js/5/core-classes/profile/save">save</a> method is called
+Updating a security profile will have no impact until the [save](/sdk/js/5/core-classes/profile/save) method is called
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/role/set-content/index.md
+++ b/src/sdk/js/5/core-classes/role/set-content/index.md
@@ -10,7 +10,7 @@ description: Role:setContent
 Replaces the content of the `Role` object.
 
 <div class="alert alert-info">
-Updating a role content will have no impact until the <a href="/sdk/js/5/core-classes/role/save">save</a> method is called
+Updating a role content will have no impact until the [save](/sdk/js/5/core-classes/role/save) method is called
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/role/update/index.md
+++ b/src/sdk/js/5/core-classes/role/update/index.md
@@ -15,7 +15,7 @@ Updates the role object in Kuzzle.
     In other words, you always need to provide the complete role definition in the <code>updateContent</code> object.
   </p>
   <p>
-    This method has the same effect as calling <a href="/sdk/js/5/core-classes/role/set-content"><code>setContent</code></a> followed by the <a href="/sdk/js/5/core-classes/role/save"><code>save</code></a> method.
+    This method has the same effect as calling [`setContent`](/sdk/js/5/core-classes/role/set-content) followed by the [`save`](/sdk/js/5/core-classes/role/save) method.
   </p>
 </div>
 

--- a/src/sdk/js/5/core-classes/security/is-action-allowed/index.md
+++ b/src/sdk/js/5/core-classes/security/is-action-allowed/index.md
@@ -16,7 +16,7 @@ Specifies if an action is allowed, denied or conditional based on the rights pro
 An action is defined as a pair of action and controller (mandatory), plus an index and a collection(optional).
 
 <div class="alert alert-info">
-You can get the rights from Kuzzle by using <a href="/sdk/js/5/core-classes/security/get-user-rights">`Security.getUserRights`</a> and <a href="/sdk/js/5/core-classes/kuzzle/get-my-rights">`Kuzzle.getMyRights`</a>.
+You can get the rights from Kuzzle by using [`Security.getUserRights`](/sdk/js/5/core-classes/security/get-user-rights) and [`Kuzzle.getMyRights`](/sdk/js/5/core-classes/kuzzle/get-my-rights).
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/security/search-users/index.md
+++ b/src/sdk/js/5/core-classes/security/search-users/index.md
@@ -31,7 +31,7 @@ Return users matching the given filter.
 | `size`     | number  |  Number of hits to return per result page                                                                                                                                                                         | `10`        |
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/user/add-profile/index.md
+++ b/src/sdk/js/5/core-classes/user/add-profile/index.md
@@ -10,7 +10,7 @@ description: User:addProfile
 Replaces the security profile associated with the user.
 
 <div class="alert alert-info">
-Updating a user will have no impact until the <a href="/sdk/js/5/core-classes/user/create"><code>create</code></a> or <a href="/sdk/js/5/core-classes/user/replace"><code>replace</code></a> method is called
+Updating a user will have no impact until the [`create`](/sdk/js/5/core-classes/user/create) or [`replace`](/sdk/js/5/core-classes/user/replace) method is called
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/user/set-content/index.md
+++ b/src/sdk/js/5/core-classes/user/set-content/index.md
@@ -10,7 +10,7 @@ description: User:setContent
 Replaces the content of User.
 
 <div class="alert alert-info">
-Updating a user will have no impact until the <a href="/sdk/js/5/core-classes/user/create"><code>create</code></a> or <a href="/sdk/js/5/core-classes/user/replace"><code>replace</code></a> method is called
+Updating a user will have no impact until the [`create`](/sdk/js/5/core-classes/user/create) or [`replace`](/sdk/js/5/core-classes/user/replace) method is called
 </div>
 
 ---

--- a/src/sdk/js/5/core-classes/user/set-credentials/index.md
+++ b/src/sdk/js/5/core-classes/user/set-credentials/index.md
@@ -10,7 +10,7 @@ description: User:setCredentials
 Sets the user's credentials.
 
 <div class="alert alert-info">
-  Updating user credentials will have no impact until the <a href="/sdk/js/5/core-classes/user/create"><code>create</code></a> method is called.<br />
+  Updating user credentials will have no impact until the [`create`](/sdk/js/5/core-classes/user/create) method is called.<br />
   The credentials to send depend on the authentication plugin and the strategy you want to create credentials for.
 </div>
 ---

--- a/src/sdk/js/6/core-classes/base-controller/properties/index.md
+++ b/src/sdk/js/6/core-classes/base-controller/properties/index.md
@@ -10,7 +10,7 @@ description: BaseController Properties
 | Property name        | Type     | Description          |
 | -------------------- | -------- | --------------------------------------- |
 | `name`               | <pre>string</pre> | Controller name    |
-| `kuzzle`             | <a href="/sdk/js/6/core-classes/kuzzle/constructor"><pre>Kuzzle</pre></a> | Kuzzle SDK instance      |
+| `kuzzle`             | [`Kuzzle`](/sdk/js/6/core-classes/kuzzle/constructor) | Kuzzle SDK instance      |
 
 **Note:**
  - The `name` property will be injected in the request sent by the [BaseController.query](/sdk/js/6/core-classes/base-controller/query) method if the `controller` property is not set.

--- a/src/sdk/js/6/getting-started/node-js/index.md
+++ b/src/sdk/js/6/getting-started/node-js/index.md
@@ -105,7 +105,7 @@ node create.js
 ```
 
 <div class="alert alert-success">
-You have now successfully stored your first document into Kuzzle. Click <a href="/core/1/guides/essentials/admin-console/">here</a> to see how you can use the
+You have now successfully stored your first document into Kuzzle. Click [here](/core/1/guides/essentials/admin-console/) to see how you can use the
    <a href="http://console.kuzzle.io" target="_blank"><strong>Kuzzle Admin Console</strong></a> to browse your collection and confirm that your document was saved.
 </div>
 
@@ -115,7 +115,7 @@ Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzz
 
 ## Subscribe to realtime document notifications (pub/sub)
 
-Kuzzle provides pub/sub features that can be used to trigger real-time notifications based on the state of your data (for a deep-dive on notifications check out the <a href="/sdk/js/6/essentials/realtime-notifications/">realtime notifications</a> documentation).
+Kuzzle provides pub/sub features that can be used to trigger real-time notifications based on the state of your data (for a deep-dive on notifications check out the [realtime notifications](/sdk/js/6/essentials/realtime-notifications/) documentation).
 
 Let's get started. Create a `subscribe.js` file with the following code:
 
@@ -151,6 +151,6 @@ Congratulations! You have just set up your first pub/sub communication!
 Now that you're more familiar with Kuzzle, dive even deeper to learn how to leverage its full capabilities:
 
 - discover what this SDK has to offer by browsing other sections of this documentation
-- learn how to use <a href="/core/1/koncorde">Koncorde</a> to create incredibly fine-grained and blazing-fast subscriptions
-- learn how to perform a <a href="/sdk/js/6/controllers/auth/login">basic authentication</a>
-- follow our guide to learn how to <a href="/core/1/guides/essentials/security/">manage users, and how to set up fine-grained access control</a>
+- learn how to use [Koncorde](/core/1/koncorde) to create incredibly fine-grained and blazing-fast subscriptions
+- learn how to perform a [basic authentication](/sdk/js/6/controllers/auth/login)
+- follow our guide to learn how to [manage users, and how to set up fine-grained access control](/core/1/guides/essentials/security/)

--- a/src/sdk/js/6/getting-started/raw-web/index.md
+++ b/src/sdk/js/6/getting-started/raw-web/index.md
@@ -120,7 +120,7 @@ New document successfully created!
 ```
 
 <div class="alert alert-success">
-You have now successfully stored your first document into Kuzzle. Click <a href="/core/1/guides/essentials/admin-console/">here</a> to see how you can use the <strong>Kuzzle Admin Console</strong> to browse your collection and confirm that your document was saved.
+You have now successfully stored your first document into Kuzzle. Click [here](/core/1/guides/essentials/admin-console/) to see how you can use the <strong>Kuzzle Admin Console</strong> to browse your collection and confirm that your document was saved.
 </div>
 
 <div class="alert alert-info">
@@ -129,7 +129,7 @@ Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzz
 
 ## Subscribe to realtime document notifications (pub/sub)
 
-Kuzzle provides pub/sub features that can be used to trigger real-time notifications based on the state of your data (for a deep-dive on notifications check out the <a href="/sdk/js/6/essentials/realtime-notifications/">realtime notifications</a> documentation).
+Kuzzle provides pub/sub features that can be used to trigger real-time notifications based on the state of your data (for a deep-dive on notifications check out the [realtime notifications](/sdk/js/6/essentials/realtime-notifications/) documentation).
 
 Let's get started. Create a `subscribe.html` file (same structure as above) with the following code in the `body` tag:
 
@@ -162,6 +162,6 @@ Congratulations! You have just set up your first pub/sub communication!
 Now that you're more familiar with Kuzzle, dive even deeper to learn how to leverage its full capabilities:
 
 - discover what this SDK has to offer by browsing other sections of this documentation
-- learn how to use <a href="/core/1/koncorde">Koncorde</a> to create incredibly fine-grained and blazing-fast subscriptions
-- learn how to perform a <a href="/sdk/js/6/controllers/auth/login">basic authentication</a>
-- follow our guide to learn how to <a href="/core/1/guides/essentials/security/">manage users, and how to set up fine-grained access control</a>
+- learn how to use [Koncorde](/core/1/koncorde) to create incredibly fine-grained and blazing-fast subscriptions
+- learn how to perform a [basic authentication](/sdk/js/6/controllers/auth/login)
+- follow our guide to learn how to [manage users, and how to set up fine-grained access control](/core/1/guides/essentials/security/)

--- a/src/sdk/js/6/getting-started/webpack/index.md
+++ b/src/sdk/js/6/getting-started/webpack/index.md
@@ -174,7 +174,7 @@ New document successfully created!
 
 <div class="alert alert-success">
     You have now successfully stored your first document into Kuzzle. Click
-    <a href="/core/1/guides/essentials/admin-console/">here</a> to see how you can use the
+    [here](/core/1/guides/essentials/admin-console/) to see how you can use the
     <strong><a href="http://console.kuzzle.io/">Kuzzle Admin Console</a></strong> to browse your collection and
     confirm that your document was saved.
 </div>
@@ -185,7 +185,7 @@ Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzz
 
 ## Subscribe to realtime document notifications (pub/sub)
 
-Kuzzle provides pub/sub features that can be used to trigger real-time notifications based on the state of your data (for a deep-dive on notifications check out the <a href="/sdk/js/6/essentials/realtime-notifications/">realtime notifications</a> documentation).
+Kuzzle provides pub/sub features that can be used to trigger real-time notifications based on the state of your data (for a deep-dive on notifications check out the [realtime notifications](/sdk/js/6/essentials/realtime-notifications/) documentation).
 
 Let's get started. Create a `subscribe.js` file with following code:
 
@@ -228,7 +228,7 @@ Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzz
 
 Now that you're more familiar with Kuzzle, dive even deeper to learn how to leverage its full capabilities:
 
-- take a look at the <a href="/sdk/js/6">SDK Reference</a>
-- learn how to use <a href="/core/1/koncorde">Koncorde</a> to create incredibly fine-grained and blazing-fast subscriptions
-- follow our guide to learn how to implement <a href="/core/1/guides/essentials/user-authentication/#local-strategy">basic authentication</a>
-- follow our guide to learn how to implement <a href="/core/1/guides/essentials/security/">manage users and setup fine-grained access control</a>
+- take a look at the [SDK Reference](/sdk/js/6)
+- learn how to use [Koncorde](/core/1/koncorde) to create incredibly fine-grained and blazing-fast subscriptions
+- follow our guide to learn how to implement [basic authentication](/core/1/guides/essentials/user-authentication/#local-strategy)
+- follow our guide to learn how to implement [manage users and setup fine-grained access control](/core/1/guides/essentials/security/)

--- a/src/sdk/js/6/protocols/http/introduction/index.md
+++ b/src/sdk/js/6/protocols/http/introduction/index.md
@@ -12,9 +12,9 @@ The Http protocol can be used by an instance of the SDK to communicate with your
 
 <div class="alert alert-info">
   <p>
-  This protocol does not allow to use the <a href="/sdk/js/6/essentials/realtime-notifications/">real-time notifications</a>.
+  This protocol does not allow to use the [real-time notifications](/sdk/js/6/essentials/realtime-notifications/).
   </p>
   <p>
-  You have to use <a href="/sdk/js/6/protocols/websocket">WebSocket</a> or <a href="/sdk/js/6/protocols/socketio">SocketIO</a> protocol instead.
+  You have to use [WebSocket](/sdk/js/6/protocols/websocket) or [SocketIO](/sdk/js/6/protocols/socketio) protocol instead.
   </p>
 </div>

--- a/src/sdk/js/6/protocols/socketio/introduction/index.md
+++ b/src/sdk/js/6/protocols/socketio/introduction/index.md
@@ -13,6 +13,6 @@ This protocol allows you to use all the features of Kuzzle, including [real-time
 
 <div class="alert alert-info">
   <p>
-  The SocketIO protocol is used for websocket compatibility with older browsers. It is preferable to use the <a href="/sdk/js/6/protocols/websocket">WebSocket</a> protocol when possible.
+  The SocketIO protocol is used for websocket compatibility with older browsers. It is preferable to use the [WebSocket](/sdk/js/6/protocols/websocket) protocol when possible.
   </p>
 </div>

--- a/src/sdk/php/3/core-classes/collection/scroll/index.md
+++ b/src/sdk/php/3/core-classes/collection/scroll/index.md
@@ -15,7 +15,7 @@ There is a small delay between the time a document is created and its availabili
 </div>
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/collection/search/index.md
+++ b/src/sdk/php/3/core-classes/collection/search/index.md
@@ -45,7 +45,7 @@ See [`SearchResult.fetchNext`](/sdk/php/3/core-classes/search-result/fetch-next/
 | `size`     | number  | Provide the maximum number of results of the request (used to paginate results)                                                                                                                                   | `10`        |
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/kuzzle/login/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/login/index.md
@@ -19,7 +19,7 @@ If the login attempt fails, the `loginAttempt` event is fired with the following
 `{ success: false, error: 'error message' }`
 
 <div class="alert alert-info">
-This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. <a href="/core/1/guides/essentials/user-authentication/#local-strategy">Learn more.</a>
+This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. [Learn more.](/core/1/guides/essentials/user-authentication/#local-strategy)
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/kuzzle/query/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/query/index.md
@@ -11,7 +11,7 @@ Base method used to send queries to Kuzzle, following the [API Documentation](/c
 
 <div class="alert alert-warning">
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.<br/>
-Refer to Kuzzle's API Reference <a href="/core/1/api">here</a>
+Refer to Kuzzle's API Reference [here](/core/1/api)
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/memory-storage/sort/index.md
+++ b/src/sdk/php/3/core-classes/memory-storage/sort/index.md
@@ -11,7 +11,7 @@ Sorts and returns elements contained in a list, a set of unique values or a sort
 By default, sorting is numeric and elements are compared by their value interpreted as double precision floating point number.
 
 <div class="alert alert-info"
-While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the <a href="/sdk/php/3/core-classes/kuzzle/query/">query method</a>
+While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the [query method](/sdk/php/3/core-classes/kuzzle/query/)
 </div>
 
 [[_Redis documentation_]](https://redis.io/commands/sort)

--- a/src/sdk/php/3/core-classes/profile/add-policy/index.md
+++ b/src/sdk/php/3/core-classes/profile/add-policy/index.md
@@ -10,7 +10,7 @@ description: Profile:addPolicy
 Adds a role to the security profile.
 
 <div class="alert alert-info">
-Updating a security profile will have no impact until the <a href="/sdk/php/3/core-classes/profile/save/">save</a> method is called
+Updating a security profile will have no impact until the [save](/sdk/php/3/core-classes/profile/save/) method is called
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/role/set-content/index.md
+++ b/src/sdk/php/3/core-classes/role/set-content/index.md
@@ -10,7 +10,7 @@ description: Role:setContent
 Replaces the content of the `Role` object.
 
 <div class="alert alert-info">
-Updating a role content will have no impact until the <a href="/sdk/php/3/core-classes/role/save/">save</a> method is called
+Updating a role content will have no impact until the [save](/sdk/php/3/core-classes/role/save/) method is called
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/role/update/index.md
+++ b/src/sdk/php/3/core-classes/role/update/index.md
@@ -15,7 +15,7 @@ Updates the role object in Kuzzle.
     In other words, you always need to provide the complete role definition in the <code>updateContent</code> object.
   </p>
   <p>
-    This method has the same effect as calling <a href="/sdk/php/3/core-classes/role/set-content/"><code>setContent</code></a> followed by the <a href="/sdk/php/3/core-classes/role/save/"><code>save</code></a> method.
+    This method has the same effect as calling [`setContent`](/sdk/php/3/core-classes/role/set-content/) followed by the [`save`](/sdk/php/3/core-classes/role/save/) method.
   </p>
 </div>
 

--- a/src/sdk/php/3/core-classes/security/is-action-allowed/index.md
+++ b/src/sdk/php/3/core-classes/security/is-action-allowed/index.md
@@ -16,7 +16,7 @@ Specifies if an action is allowed, denied or conditional based on the rights pro
 An action is defined as a pair of action and controller (mandatory), plus an index and a collection(optional).
 
 <div class="alert alert-info">
-You can get the rights from Kuzzle by using <a href="/sdk/php/3/core-classes/security/get-user-rights/">`Security.getUserRights`</a> and <a href="/sdk/php/3/core-classes/kuzzle/get-my-rights/">`Kuzzle.getMyRights`</a>.
+You can get the rights from Kuzzle by using [`Security.getUserRights`](/sdk/php/3/core-classes/security/get-user-rights/) and [`Kuzzle.getMyRights`](/sdk/php/3/core-classes/kuzzle/get-my-rights/).
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/security/search-users/index.md
+++ b/src/sdk/php/3/core-classes/security/search-users/index.md
@@ -31,7 +31,7 @@ Return users matching the given filter.
 | `size`     | number  |  Number of hits to return per result page                                                                                                                                                                         | `10`        |
 
 <div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the <a href="/core/1/api/controllers/document/search/">API reference documentation</a>.
+  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/user/add-profile/index.md
+++ b/src/sdk/php/3/core-classes/user/add-profile/index.md
@@ -10,7 +10,7 @@ description: User:addProfile
 Replaces the security profile associated with the user.
 
 <div class="alert alert-info">
-Updating a user will have no impact until the <a href="/sdk/php/3/core-classes/user/create/"><code>create</code></a> or <a href="/sdk/php/3/core-classes/user/replace/"><code>replace</code></a> method is called
+Updating a user will have no impact until the [`create`](/sdk/php/3/core-classes/user/create/) or [`replace`](/sdk/php/3/core-classes/user/replace/) method is called
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/user/set-content/index.md
+++ b/src/sdk/php/3/core-classes/user/set-content/index.md
@@ -10,7 +10,7 @@ description: User:setContent
 Replaces the content of User.
 
 <div class="alert alert-info">
-Updating a user will have no impact until the <a href="/sdk/php/3/core-classes/user/create/"><code>create</code></a> or <a href="/sdk/php/3/core-classes/user/replace/"><code>replace</code></a> method is called
+Updating a user will have no impact until the [`create`](/sdk/php/3/core-classes/user/create/) or [`replace`](/sdk/php/3/core-classes/user/replace/) method is called
 </div>
 
 ---

--- a/src/sdk/php/3/core-classes/user/set-credentials/index.md
+++ b/src/sdk/php/3/core-classes/user/set-credentials/index.md
@@ -10,7 +10,7 @@ description: User:setCredentials
 Sets the user's credentials.
 
 <div class="alert alert-info">
-  Updating user credentials will have no impact until the <a href="/sdk/php/3/core-classes/user/create/"><code>create</code></a> method is called.<br />
+  Updating user credentials will have no impact until the [`create`](/sdk/php/3/core-classes/user/create/) method is called.<br />
   The credentials to send depend on the authentication plugin and the strategy you want to create credentials for.
 </div>
 ---


### PR DESCRIPTION
## What does this PR do?
Replaces all the `<a>` tags in the `Sidebar` component (and others) with `<router-link>` so that the entire website behaves like an SPA after first load.

Thanks to @alexandrebouthinon for helping on this! :tada: 

### How should this be manually tested?
Build the docs locally and navigate with the Network tab of your Devtools open. You'll see that only a tiny js script is loaded after clicking on a link.

### Other changes
The same substitution is operated on the following components

* Redirect.vue
* SDKIndex.vue
* Tabs.vue
* TabsMobile.vue
