### PR TITLE
Disable Java and C++ tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,16 +87,16 @@ jobs:
     #     - bash ./run-snippet-tests.sh -p src -s java -v 1
 
 
-    - stage: Tests
-      name: Kuzzle SDK C++ - v1
+    # - stage: Tests
+    #   name: Kuzzle SDK C++ - v1
 
-      before_install:
-        - docker pull kuzzleio/documentation:cpp
-        - sysctl -w vm.max_map_count=262144
+    #   before_install:
+    #     - docker pull kuzzleio/documentation:cpp
+    #     - sysctl -w vm.max_map_count=262144
 
-      script:
-        - npm install
-        - bash ./run-snippet-tests.sh -p src -s cpp -v 1
+    #   script:
+    #     - npm install
+    #     - bash ./run-snippet-tests.sh -p src -s cpp -v 1
 
 
     - stage: Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,16 +75,16 @@ jobs:
         - bash ./run-snippet-tests.sh -p src -s go -v 1
 
 
-    - stage: Tests
-      name: Kuzzle SDK Java - v1
+    # - stage: Tests
+    #   name: Kuzzle SDK Java - v1
 
-      before_install:
-        - docker pull kuzzleio/documentation:java
-        - sysctl -w vm.max_map_count=262144
+    #   before_install:
+    #     - docker pull kuzzleio/documentation:java
+    #     - sysctl -w vm.max_map_count=262144
 
-      script:
-        - npm install
-        - bash ./run-snippet-tests.sh -p src -s java -v 1
+    #   script:
+    #     - npm install
+    #     - bash ./run-snippet-tests.sh -p src -s java -v 1
 
 
     - stage: Tests


### PR DESCRIPTION
## What does this PR do?

https://jira.kaliop.net/browse/KZL-1204

Disables the Java snippet tests, since they are executed on the Swig version of the SDK and are not reliable.