### PR TITLE
[HOTFIX] SDK selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-poc",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/.vuepress/components/SDKSelector.vue
+++ b/src/.vuepress/components/SDKSelector.vue
@@ -16,16 +16,17 @@
       <li
         class="selector-list-item"
         v-for="item in items"
-        :key="item.language + item.version"
         v-show="isListShowed"
+        :key="item.language + item.version"
+        @click="toggleList()"
       >
-        <a
+        <router-link
           class="selector-list-item-link"
-          :href="generateLink(`/sdk-reference/${item.language}/${item.version}/`)"
+          :to="{path: generateLink(`/sdk/${item.language}/${item.version}/`)}"
         >
           <img class="selector-list-item-icon" :src="item.icon" :alt="item.language">
           <span class="selector-list-item-name">{{ item.name }}</span>
-        </a>
+        </router-link>
       </li>
     </ul>
   </div>
@@ -66,7 +67,7 @@ export default {
       const el = this.$refs.selector,
         target = e.target;
 
-      if (el !== target && !el.contains(target)) {
+      if (el && el !== target && !el.contains(target)) {
         this.isListShowed = false;
       }
     }

--- a/src/.vuepress/theme/Layout.vue
+++ b/src/.vuepress/theme/Layout.vue
@@ -12,7 +12,7 @@
           <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
             <div class="md-sidebar__scrollwrap">
               <div class="md-sidebar__inner">
-                <div v-if="$route.path.match('/sdk-reference/')" class="selector-container">
+                <div v-if="$route.path.match(/^\/sdk\//)" class="selector-container">
                   <SDKSelector :items="sdkList"/>
                 </div>
                 <TOC/>

--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -126,7 +126,7 @@ export default {
     // If you find a better way to determine when the page has finished rendering,
     // you're my hero.
     setTimeout(() => {
-      if (!this.isInViewport(activeLink)) {
+      if (activeLink && !this.isInViewport(activeLink)) {
         this.$refs.scrollwrap.scrollTop = activeLink.offsetTop - 50;
       }
     }, 500);


### PR DESCRIPTION
* SDK selector is now visible on SDK pages
* SDK selector now uses `router-link` instead of `a`

### How should this be manually tested?
Go to a SDK doc page.

### Boyscout

* Fixes minor errors in SDK selector and Sidebar
