### PR TITLE
[HOTFIX] Redirect branches to first page

### DIFF
--- a/src/.vuepress/theme/Layout.vue
+++ b/src/.vuepress/theme/Layout.vue
@@ -44,6 +44,8 @@ import ContentFeedback from './ContentFeedback.vue';
 import Footer from './Footer.vue';
 import sdkList from '../sdk.json';
 
+const { getFirstValidChild } = require('../util.js');
+
 export default {
   components: { Header, Sidebar, TOC, ContentFeedback, Footer },
   data() {
@@ -141,6 +143,10 @@ export default {
     }
   },
   mounted() {
+    if (this.$page.frontmatter.type !== 'page') {
+      this.$router.replace(getFirstValidChild(this.$page, this.$site.pages));
+      return;
+    }
     // TODO condition isSupported()
     const copy = new Clipboard('.md-clipboard', {
       target: trigger => {

--- a/src/core/1/guides/code-examples/dbsearch/index.md
+++ b/src/core/1/guides/code-examples/dbsearch/index.md
@@ -6,4 +6,4 @@ order: 400
 description: Database Code Examples
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/code-examples/geofencing/index.md
+++ b/src/core/1/guides/code-examples/geofencing/index.md
@@ -6,4 +6,4 @@ order: 500
 description: Geofencing Code Examples
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/code-examples/iot/index.md
+++ b/src/core/1/guides/code-examples/iot/index.md
@@ -6,4 +6,4 @@ order: 600
 description: IoT Code Examples
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/code-examples/pubsub/index.md
+++ b/src/core/1/guides/code-examples/pubsub/index.md
@@ -6,4 +6,4 @@ order: 700
 description: Pub/Sub Code Examples
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/cookbooks/datavalidation/index.md
+++ b/src/core/1/guides/cookbooks/datavalidation/index.md
@@ -6,4 +6,4 @@ order: 400
 description: The reference for the data-validation engine in Kuzzle.
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/cookbooks/elasticsearch/index.md
+++ b/src/core/1/guides/cookbooks/elasticsearch/index.md
@@ -6,4 +6,4 @@ order: 350
 description: Elasticsearch cookbook
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/essentials/index.md
+++ b/src/core/1/guides/essentials/index.md
@@ -6,4 +6,4 @@ description: learn mechanisms of kuzzle
 order: 200
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/getting-started/index.md
+++ b/src/core/1/guides/getting-started/index.md
@@ -6,4 +6,4 @@ description: learn kuzzle in a few steps
 order: 100
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/index.md
+++ b/src/core/1/guides/index.md
@@ -6,4 +6,4 @@ title: Guides
 description: Kuzzle v1.x Guides
 ---
 
-<RedirectToFirstChild />
+

--- a/src/core/1/guides/kuzzle-depth/index.md
+++ b/src/core/1/guides/kuzzle-depth/index.md
@@ -5,4 +5,4 @@ title: Kuzzle in Depth
 order: 500
 ---
 
-<RedirectToFirstChild />
+

--- a/src/index.md
+++ b/src/index.md
@@ -6,4 +6,4 @@ title: Kuzzle Documentation
 description: Kuzzle Documentation
 ---
 
-<RedirectToFirstChild />
+


### PR DESCRIPTION
## What does this PR do?

Moves the `redirectToFirstChild` logic to the Layout component, so that it's applied to all the nodes that are not `type: page`.
The `<RedirectToFirstChild/>` component has been taken off the Markdown files.

### How should this be manually tested?
Go to the URL of a branch, like `/core/1/guides/` and see it redirecting to the first valid page.