### PR TITLE
Use the new alert tags instead of raw HTML div tags

### DIFF
--- a/check_link.rb
+++ b/check_link.rb
@@ -104,8 +104,8 @@ class LinkChecker
       external_link.start_with?(*IGNORED_EXTERNAL_LINKS) ||
       external_link == 'http://'
     end.each do |external_link|
-      # Remove markdown parenthesis and other garbage
-      external_link.gsub!(/[\)][\.:,]*/, '')
+      # Remove markdown closing parenthesis and everything following it
+      external_link.gsub!(/[\)].*/, '')
 
       request = Typhoeus::Request.new(external_link, followlocation: true)
 

--- a/check_link.rb
+++ b/check_link.rb
@@ -59,7 +59,7 @@ class LinkChecker
     puts
 
     puts "Found #{@external.count} uniq external dead links:\n"
-    puts @internal.to_a
+    puts @external.to_a
     puts
   end
 

--- a/src/core/1/api/essentials/connecting-to-kuzzle/index.md
+++ b/src/core/1/api/essentials/connecting-to-kuzzle/index.md
@@ -100,9 +100,9 @@ Kuzzle {
 
 By default, the MQTT plugin protocol listens on port 1883.
 
-<div class="alert alert-info">
-    The examples given in this documentation use the CLI client from the mqtt node.js
-    library that is shipped in the Kuzzle Docker image.<br />
-    To test them out yourself you will need to enter into the container shell once your docker compose stack is up and running:<br />
-    <code>docker exec -ti kuzzle_kuzzle_1 bash</code>
-</div>
+:::info
+The examples given in this documentation use the CLI client from the mqtt node.js
+library that is shipped in the Kuzzle Docker image.  
+To test them out yourself you will need to enter into the container shell once your docker compose stack is up and running:  
+`docker exec -ti kuzzle_kuzzle_1 bash`
+:::

--- a/src/core/1/api/essentials/query-syntax/index.md
+++ b/src/core/1/api/essentials/query-syntax/index.md
@@ -45,7 +45,9 @@ If the form field holds a file, then the corresponding JSON key will refer to an
 
 ## Other protocols
 
-<div class="alert alert-info">Kuzzle's extensible protocol system allows communication in virtually any format. This documentation section describes the format that must be used to pass queries to Kuzzle itself, either directly by users (for instance, our <a href="https://github.com/kuzzleio/protocol-mqtt">MQTT protocol</a>), or indirectly, translated by the custom protocol layer.</div>
+:::info
+Kuzzle's extensible protocol system allows communication in virtually any format. This documentation section describes the format that must be used to pass queries to Kuzzle itself, either directly by users (for instance, using the embedded WebSocket or MQTT protocols), or indirectly, translated by the custom protocol layer.
+:::
 
 Queries made to Kuzzle must be encoded using JSON, and have the following format:
 

--- a/src/core/1/guides/cookbooks/datavalidation/fields/index.md
+++ b/src/core/1/guides/cookbooks/datavalidation/fields/index.md
@@ -146,7 +146,9 @@ This configuration is available depending on the types of the field.
 - Only date: "2010-12-25"
 - Time relative to the current day : "T14:12:44"
 
-<div class="alert alert-warning">Beware when using dates as range values: always make sure that, at some point, your rule won't prevent all documents from entering the system.</div>
+:::warning
+Beware when using dates as range values: always make sure that, at some point, your rule won't prevent all documents from entering the system.
+:::
 
 #### typeOptions.length
 
@@ -271,13 +273,13 @@ strict_year_month_day
 
 **Purpose**: Define the accepted formats that can be used for dates
 
-<div class="alert alert-warning">
+:::warning
 The format defined in the specification has to match the formats defined in the Elasticsearch mapping for the field.
-<br/>
-Non strict mode is slightly different from the one explained and implemented by Elasticsearch. Please refer to the <a href="http://momentjs.com/guides/#/parsing/strict-mode/">Moment.js documentation</a> for further details, this is the date library we use internally.
-<br/>
+
+Non strict mode is slightly different from the one explained and implemented by Elasticsearch. Please refer to the [Moment.js documentation](http://momentjs.com/guides/#/parsing/strict-mode/) for further details, this is the date library we use internally.
+
 Non strict mode has been implemented to fit Elasticsearch date formats but we recommend to use strict mode when possible.
-</div>
+:::
 
 #### typeOptions.strict
 

--- a/src/core/1/guides/cookbooks/datavalidation/validators/index.md
+++ b/src/core/1/guides/cookbooks/datavalidation/validators/index.md
@@ -10,8 +10,6 @@ order: 200
 
 The `validators` property is an array of [Koncorde filters](/core/1/koncorde/#FIXME). Each filter has to match in order for the document to be valid.
 
-<div class="alert alert-warning">You have to be careful with fields that are empty or undefined.</div>
-
 ## Structure
 
 ```json

--- a/src/core/1/guides/cookbooks/elasticsearch/data-insertion/index.md
+++ b/src/core/1/guides/cookbooks/elasticsearch/data-insertion/index.md
@@ -17,11 +17,11 @@ We use the `?pretty` keyword to get human-readable outputs from our requests.
 We will provide Elasticsearch with a mapping (RDBM: schema) for the data we want to index.
 Here we create a new document `type` (RDBM: table) called `blogpost` with 6 fields (RDBM: columns).
 
-<div class="alert alert-warning">
-  The mapping is not mandatory, but if you don't define it before pushing data to Elasticsearch,
-  Elasticsearch will infer the mapping for each field based on its content.
-  Once defined, the field type cannot be changed.
-</div>
+:::warning
+The mapping is not mandatory, but if you don't define it before pushing data to Elasticsearch,
+Elasticsearch will infer the mapping for each field based on its content.
+Once defined, the field type cannot be changed.
+:::
 
 ```bash
 curl -g -X PUT "http://localhost:9200/example/?pretty" -d '{

--- a/src/core/1/guides/essentials/admin-console/index.md
+++ b/src/core/1/guides/essentials/admin-console/index.md
@@ -9,13 +9,13 @@ order: 100
 
 The Kuzzle Admin Console is a web application that lets you manage Kuzzle, including **data**, **real-time notifications** and **security**.
 
-If you don't want to install Kuzzle Admin Console yourself you can use our <a href="http://console.kuzzle.io/">publicly hosted</a> Kuzzle Admin Console. Otherwise, grab the source code [here](https://github.com/kuzzleio/kuzzle-admin-console/releases) and install it on your own environment.
+If you don't want to install Kuzzle Admin Console yourself you can use our [pubicly hosted](http://console.kuzzle.io/) Admin Console. Otherwise, grab the [source code](https://github.com/kuzzleio/kuzzle-admin-console) and install it on your  environment.
 
 In both cases the configuration is the same and you'll be able to select which [Kuzzle](/core/1/guides/essentials/admin-console/#connect-to-kuzzle) installation you want to manage.
 
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
 
 ## Connect to Kuzzle
 
@@ -27,11 +27,9 @@ At any time, you can reconfigure the Kuzzle Admin Console to connect to any Kuzz
 
 To create a connection to Kuzzle, provide its **name** (e.g. "Development" or "My First Kuzzle"), **address** (or hostname) and **port**. Optionally, select a **color** to identify the connection (e.g. red could be used to identify production environments).
 
-<div class="alert alert-success">Your Kuzzle Admin Console is now connected to Kuzzle.</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::success
+Your Kuzzle Admin Console is now connected to Kuzzle.
+:::
 
 ## Create an Admin Account
 
@@ -41,8 +39,6 @@ At this point Kuzzle is not secure and any `anonymous` user has full access. The
 
 Once the Admin Account credentials have been created, use them to login.
 
-<div class="alert alert-success">You can now manage Kuzzle via the Kuzzle Admin Console.</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::success
+You can now manage Kuzzle via the Kuzzle Admin Console.
+:::

--- a/src/core/1/guides/essentials/cli/index.md
+++ b/src/core/1/guides/essentials/cli/index.md
@@ -63,8 +63,6 @@ When Kuzzle runs for the first time, no users are defined and the anonymous user
 
 The `createFirstAdmin` command lets you create an administrator to manage security.
 
-<div class="alert alert-info">NB: This command can only be run interactively</div>
-
 This call the action [security#createFirstAdmin](/core/1/api/controllers/security/create-first-admin/)
 
 ---

--- a/src/core/1/guides/essentials/configuration/index.md
+++ b/src/core/1/guides/essentials/configuration/index.md
@@ -75,6 +75,6 @@ services:
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
 ```
 
-<div class="alert alert-info">
-  For an exhaustive list of configuration parameters, please refer to the <a href="https://github.com/kuzzleio/kuzzle/blob/master/.kuzzlerc.sample">sample</a> kuzzlerc file.
-</div>
+:::info
+For an exhaustive list of configuration parameters, please refer to the [kuzzlerc sample file](https://github.com/kuzzleio/kuzzle/blob/master/.kuzzlerc.sample).
+:::

--- a/src/core/1/guides/essentials/data-validation/index.md
+++ b/src/core/1/guides/essentials/data-validation/index.md
@@ -98,9 +98,9 @@ For more information regarding Type Options, please refer to [this](/core/1/guid
 
 If the basic validation functionality doesn't meet your requirements, you can take advantage of [Koncorde](/core/1/koncorde) to create complex validation specifications.
 
-<div class="alert alert-info">
+:::info
 Koncorde is the same component used to create real-time subscriptions.
-</div>
+:::
 
 The idea is simple: use Koncorde to specify a filter that can be used to validate documents. For example, here we ensure that at least one of the fields `price` or `vatPrice` exists by placing a filter in the `validators` field of the validation schema:
 

--- a/src/core/1/guides/essentials/plugins/index.md
+++ b/src/core/1/guides/essentials/plugins/index.md
@@ -47,9 +47,9 @@ Kuzzle ships with the [Local Strategy Plugin](https://github.com/kuzzleio/kuzzle
 
 ## Installing a Plugin
 
-<div class="alert alert-info">
+:::info
 If you are running Kuzzle in a Docker container, you will need to access the running container's shell and then the Kuzzle installation folder inside the container.
-</div>
+:::
 
 To install a plugin, you need to make it accessible in the `plugins/enabled` folder of your Kuzzle installation.
 

--- a/src/core/1/guides/getting-started/first-steps/index.md
+++ b/src/core/1/guides/getting-started/first-steps/index.md
@@ -12,8 +12,12 @@ It's time to play with the [Kuzzle JS SDK](/sdk). In this section, we will learn
 
 Before proceeding, please make sure your system has these programs installed:
 
-- **Node.js** version 6 or higher (<a href="https://nodejs.org/en/download/">instructions here</a>)
+- **Node.js** version 6 or higher ([download page](https://nodejs.org/en/download/))
 - Kuzzle
+
+:::info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
 
 ## Prepare your environment
 
@@ -25,9 +29,9 @@ cd kuzzle-playground
 npm install kuzzle-sdk
 ```
 
-<div class="alert alert-info">
+:::info
 If you are performing a clean install you might see some `UNMET PEER DEPENDENCY` warnings, these are safe to ignore as they refer to optional dependencies.
-</div>
+:::
 
 Then, create an `init.js` file and start by loading the Kuzzle Javascript SDK.
 Next, instantiate a client that automatically connects to Kuzzle via WebSocket. Replace `'kuzzle'` with the corresponding server name or IP address:
@@ -62,13 +66,9 @@ Your console should output the following message:
 playground/mycollection ready
 ```
 
-<div class="alert alert-success">
+:::success
 Congratulations! You are now ready to say Hello to the World!
-</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::
 
 ## Create your first "Hello World" document
 
@@ -95,14 +95,9 @@ Your console should show the following message:
 document created
 ```
 
-<div class="alert alert-success">
-You have now successfully stored your first document into Kuzzle. Click core/1/guides/essentials/admin-console/">here</a> to see how you can use the
-  <strong>Kuzzle Admin Console</strong> to browse your collection and confirm that your document was saved.
-</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::success
+You have now successfully stored your first document into Kuzzle. Check the [Admin Console Guide](/core/1/guides/essentials/admin-console/) to see how to browse your collection and confirm that your document was saved.
+:::
 
 _You can find more resources about Kuzzle SDK in the [SDK Reference](/sdk)._
 
@@ -128,13 +123,9 @@ document created
 message received from kuzzle: Hello, World!
 ```
 
-<div class="alert alert-success">
+:::success
 Congratulations! You have just choreographed your first pub/sub pattern!
-</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::
 
 ## Where do we go from here?
 

--- a/src/core/1/guides/getting-started/running-kuzzle/index.md
+++ b/src/core/1/guides/getting-started/running-kuzzle/index.md
@@ -50,9 +50,8 @@ Congratulations! You have completed the Kuzzle installation, it will now accept 
 ::: info
 Having trouble?
 
-- Get in touch with us on [Gitter!](https://gitter.im/kuzzleio/kuzzle) We're happy to help.
-- Try one of [these](/core/1/guides/essentials/installing-kuzzle/) alternative installation methods.
-
+- Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)
+- Try one of [these](/core/1/guides/essentials/installing-kuzzle/) alternative installation methods
 :::
 
 #### Helper scripts for systemd

--- a/src/core/1/koncorde/essentials/operands/index.md
+++ b/src/core/1/koncorde/essentials/operands/index.md
@@ -13,10 +13,10 @@ the available operands. Operands allow you to combine multiple terms together in
 You can also refer to the [terms](/core/1/koncorde/essentials/terms) reference to know about
 all the available terms.
 
-<div class="alert alert-info">
+:::info
 Note that the ability to combine multiple terms together allows to create different filters that have equivalent scope.
 Such filters are optimized by Koncorde, thus [internally represented by the same ID](/core/1/koncorde/essentials/advanced#filter-equivalence-default).
-</div>
+:::
 
 ## and
 

--- a/src/core/1/plugins/essentials/getting-started/index.md
+++ b/src/core/1/plugins/essentials/getting-started/index.md
@@ -39,9 +39,10 @@ The main Plugin class is defined in the `index.js`. You can start edit it adding
 
 We need to provide the `configuration` and the `context` to plugins. In that purpose, plugins must have an `init` function which will have them as parameters : this `init` function is the very first one to be called by Kuzzle and is mandatory to start a plugin. You can now write your own functions and your own routes as described inside the `index.js`. You can also write unit tests : see `steps.js`.
 
-<div class="alert alert-info">
-You can find more information about the <code>init</code> function [ here](/core/1/plugins/guides/manual-setup/init-function/).
-</div>
-<div class="alert alert-success">
+:::info
+You can find more information about the `init` function [here](/core/1/plugins/guides/manual-setup/init-function/).
+:::
+
+:::success
 You have now everything you need to start writing your own Kuzzle plugin.
-</div>
+:::

--- a/src/core/1/plugins/guides/events/core-auth-strategy-added/index.md
+++ b/src/core/1/plugins/guides/events/core-auth-strategy-added/index.md
@@ -14,7 +14,9 @@ title: core:auth:strategyAdded
 
 Triggered whenever a plugin [dynamically registers](/core/1/plugins/plugin-context/accessors/strategies/) an authentication strategy.
 
-<div class="alert alert-info">Pipes cannot listen to that event, only hooks can.</div>
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::
 
 ---
 

--- a/src/core/1/plugins/guides/events/core-auth-strategy-removed/index.md
+++ b/src/core/1/plugins/guides/events/core-auth-strategy-removed/index.md
@@ -14,7 +14,9 @@ title: core:auth:strategyRemoved
 
 Triggered whenever a plugin [dynamically removes](/core/1/plugins/plugin-context/accessors/strategies/) an authentication strategy.
 
-<div class="alert alert-info">Pipes cannot listen to that event, only hooks can.</div>
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::
 
 ---
 

--- a/src/core/1/plugins/guides/events/core-kuzzle-start/index.md
+++ b/src/core/1/plugins/guides/events/core-kuzzle-start/index.md
@@ -10,4 +10,6 @@ title: core:kuzzleStart
 
 Triggered when Kuzzle has finished booting and is ready to process user requests.
 
-<div class="alert alert-info">Pipes cannot listen to that event, only hooks can.</div>
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::

--- a/src/core/1/plugins/guides/events/core-overload/index.md
+++ b/src/core/1/plugins/guides/events/core-overload/index.md
@@ -18,4 +18,6 @@ The requests buffer is configurable through the `limits` parameters in the [Kuzz
 
 Requests submitted while the request buffer is completely filled (i.e. the payload is equal to `100`) are rejected with a [ServiceUnavailableError](/core/1/api/essentials/errors/#common-errors-default) (code `503`)
 
-<div class="alert alert-info">Pipes cannot listen to that event, only hooks can.</div>
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::

--- a/src/core/1/plugins/guides/events/room-new/index.md
+++ b/src/core/1/plugins/guides/events/room-new/index.md
@@ -14,7 +14,9 @@ title: room:new
 
 Triggered whenever a new [subscription](/core/1/api/controllers/realtime/subscribe/) is created.
 
-<div class="alert alert-info">Pipes cannot listen to that event, only hooks can.</div>
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::
 
 ---
 

--- a/src/core/1/plugins/guides/events/room-remove/index.md
+++ b/src/core/1/plugins/guides/events/room-remove/index.md
@@ -14,4 +14,6 @@ title: room:remove
 
 Triggered whenever a real-time subscription is cancelled.
 
-<div class="alert alert-info">Pipes cannot listen to that event, only hooks can.</div>
+:::info
+Pipes cannot listen to that event, only hooks can.
+:::

--- a/src/core/1/plugins/guides/pipes/index.md
+++ b/src/core/1/plugins/guides/pipes/index.md
@@ -14,7 +14,9 @@ Pipes can:
 - Decide to abort a task. If a pipe throws an error, Kuzzle interrupts the task, and forwards a standardized version of the thrown error to the originating user
 - Change the received information. Kuzzle will use the updated information upon resuming the task
 
-<div class="alert alert-warning">If a pipe takes too long to respond, Kuzzle will eventually abort the entire task with a [GatewayTimeout](/core/1/plugins/plugin-context/errors/gatewaytimeouterror) error. The timeout value can be changed in the [configuration files.](/core/1/guides/essentials/configuration/)</div>
+:::warning
+If a pipe takes too long to respond, Kuzzle will eventually abort the entire task with a [GatewayTimeout](/core/1/plugins/plugin-context/errors/gatewaytimeouterror) error. The timeout value can be changed in the [configuration files](/core/1/guides/essentials/configuration/).
+:::
 
 ---
 
@@ -36,7 +38,9 @@ Pipes must notify Kuzzle about their completion by one of these two means:
 - by calling the `callback(error, request)` function received as their last argument (leave the `error` null if the pipe executed successfully)
 - by returning a promise, resolved (or rejected) with a valid [Request](/core/1/guides/essentials/request-and-response-format/) upon the completion of the pipe
 
-<div class="alert alert-warning">You must either call the callback with a valid [Request](/core/1/guides/essentials/request-and-response-format/) or return a promise resolving to one.</div>
+:::warning
+You must either call the callback with a valid [Request](/core/1/guides/essentials/request-and-response-format/) or return a promise resolving to one.
+:::
 
 If a pipe throws an error, it is advised to throw one of the available [KuzzleError](/core/1/plugins/plugin-context/errors/kuzzleerror) object. Otherwise, Kuzzle will reject the task with a `PluginImplementationError` error.
 

--- a/src/core/1/plugins/guides/strategies/auth-functions/index.md
+++ b/src/core/1/plugins/guides/strategies/auth-functions/index.md
@@ -52,7 +52,9 @@ create(request, credentials, kuid, strategy);
 
 The `create` function must return a promise, resolving to an object. The content of that object depends on this authentication strategy; usually a feedback about the created credentials is expected. That object can be left empty.
 
-<div class="alert alert-warning">The object resolved by the promise is directly forwarded to the originating user. For security reasons, it must only contain <strong>non sensitive</strong> information.</div>
+:::warning
+The object resolved by the promise is directly forwarded to the originating user. For security reasons, it must only contain *non sensitive* information.
+:::
 
 ---
 
@@ -127,7 +129,9 @@ update(request, credentials, kuid, strategy);
 
 The `update` function must return a promise, resolving to an object. The content of that object depends on this authentication strategy; usually a feedback about the updated credentials is expected. That object can be left empty.
 
-<div class="alert alert-warning">The object resolved by the promise is directly forwarded to the originating user. For security reasons, it must only contain <strong>non sensitive</strong> information.</div>
+:::warning
+The object resolved by the promise is directly forwarded to the originating user. For security reasons, it must only contain *non sensitive* information.
+:::
 
 ---
 
@@ -200,7 +204,9 @@ The `verify` function must return a promise, resolving to an object with the fol
 | `kuid`     | <pre>string</pre> | If the authentication succeeds, this property must be set to the user's [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid). Otherwise, this must be set to `null` |
 | `message`  | <pre>string</pre> | If `kuid` is set to `null` (authentication failed), this optional property can be set with a rejection reason                                                                                            |
 
-<div class="alert alert-info">A failed authentication is not an error. The returned promise should only be rejected if an actual error occurs.</div>
+:::info
+A failed authentication is not an error. The returned promise should only be rejected if an actual error occurs.
+:::
 
 ---
 
@@ -228,7 +234,9 @@ The `getById` function returns credentials information using the authentication 
 
 If this function is not implemented, an empty object is returned by Kuzzle instead.
 
-<div class="alert alert-warning">The returned information can be forwarded to users. For security reasons, it must only contain <strong>non sensitive</strong> information.</div>
+:::warning
+The returned information can be forwarded to users. For security reasons, it must only contain *non sensitive* information.
+:::
 
 ### Arguments
 
@@ -256,7 +264,9 @@ The `getInfo` function returns information about a user's credentials.
 
 If this function is not implemented, an empty object is returned by Kuzzle instead.
 
-<div class="alert alert-warning">The returned information can be forwarded to users. For security reasons, it must only contain <strong>non sensitive</strong> information.</div>
+:::warning
+The returned information can be forwarded to users. For security reasons, it must only contain *non sensitive* information.
+:::
 
 ### Arguments
 

--- a/src/core/1/plugins/plugin-context/accessors/strategies/index.md
+++ b/src/core/1/plugins/plugin-context/accessors/strategies/index.md
@@ -82,9 +82,9 @@ Removes an authentication strategy, preventing new authentications from using it
 
 In a cluster environment, the new strategy is automatically removed from all server nodes.
 
-<div class="alert alert-warning">
+:::warning
 Authentication tokens previously created using that strategy ARE NOT invalidated after using this method.
-</div>
+:::
 
 ### Arguments
 

--- a/src/core/1/protocols/native-protocols/http/index.md
+++ b/src/core/1/protocols/native-protocols/http/index.md
@@ -20,9 +20,9 @@ The protocol can be configured via the [kuzzlerc configuration file](/core/1/gui
 
 ### Configure listening port
 
-<div class="alert alert-warning">
+:::warning
 HTTP, WebSocket and Socket.IO protocols share the same underlying server instance. Modifying the listening port will impact all these three protocols.
-</div>
+:::
 
 By default, Kuzzle listens to the `7512` port.
 

--- a/src/core/1/protocols/native-protocols/mqtt/index.md
+++ b/src/core/1/protocols/native-protocols/mqtt/index.md
@@ -7,9 +7,9 @@ order: 0
 
 # MQTT
 
-<div class="alert alert-warning">
-By default, the MQTT protocol is disabled in Kuzzle configuration.
-</div
+:::warning
+By default, the MQTT protocol is disabled in the Kuzzle configuration.
+:::
 
 ---
 
@@ -148,9 +148,9 @@ If `allowPubSub` is set to `false`, clients can only publish to the `requestTopi
 
 If `allowPubSub` is set to `true`, clients are only forbidden to publish to the `responseTopic` topic (defaults to `Kuzzle/response`).
 
-<div class="alert alert-warning">
-    Wildcards subcriptions are not allowed
-</div
+:::warning
+Wildcards subcriptions are not allowed
+:::
 
 If a client tries to publich to an unauthorized topic, his connection will immediately be shut down by the server.
 
@@ -167,9 +167,9 @@ Many CLI tools, such as Mosquitto offer two separate binaries, one for subscribi
 
 To use these tools, one can enable the **development mode**, in which `Kuzzle/response` will act as a regular public topic.
 
-<div class="alert alert-warning">
-    Do not use development mode in production!
-</div
+:::warning
+Do not use development mode in production!
+:::
 
 To enable development mode, you will need to **both** set `NODE_ENV` environment variable to `development` and set the mqtt protocol `developmentMode` to `true`:
 

--- a/src/core/1/protocols/native-protocols/socketio/index.md
+++ b/src/core/1/protocols/native-protocols/socketio/index.md
@@ -18,9 +18,9 @@ The protocol can be configured via the [kuzzlerc configuration file](/core/1/gui
 
 ### Configure listening port
 
-<div class="alert alert-warning">
+:::warning
 HTTP, WebSocket and Socket.IO protocols share the same underlying server instance. Modifying the listening port will impact all these three protocols.
-</div>
+:::
 
 By default, Kuzzle listens to the `7512` port.
 

--- a/src/core/1/protocols/native-protocols/websocket/index.md
+++ b/src/core/1/protocols/native-protocols/websocket/index.md
@@ -18,9 +18,9 @@ The protocol can be configured via the [kuzzlerc configuration file](/core/1/gui
 
 ### Configure listening port
 
-<div class="alert alert-warning">
+:::warning
 HTTP, WebSocket and Socket.IO protocols share the same underlying server instance. Modifying the listening port will impact all these three protocols.
-</div>
+:::
 
 By default, Kuzzle listens to the `7512` port.
 

--- a/src/sdk/android/3/core-classes/collection-mapping/constructor/index.md
+++ b/src/sdk/android/3/core-classes/collection-mapping/constructor/index.md
@@ -13,9 +13,9 @@ This means that, by default, you won't be able to exploit the full capabilities 
 
 The CollectionMapping object allows you to get the current mapping in a collection and to modify it if necessary.
 
-<div class="alert alert-info">
+:::info
 Once a field mapping has been set, it cannot be removed without reconstructing the collection.
-</div>
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/collection-mapping/set/index.md
+++ b/src/sdk/android/3/core-classes/collection-mapping/set/index.md
@@ -9,9 +9,9 @@ description: CollectionMapping:set
 
 Adds or updates a field mapping.
 
-<div class="alert alert-info">
-Changes made by this function won't be applied until you call the <code>apply</code> method
-</div>
+:::info
+Changes made by this function won't be applied until you call the `apply` method
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/collection/count/index.md
+++ b/src/sdk/android/3/core-classes/collection/count/index.md
@@ -9,9 +9,9 @@ description: Collection:count
 
 Returns the number of documents matching the provided set of filters.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be immediately returned by this function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/collection/delete-document/index.md
+++ b/src/sdk/android/3/core-classes/collection/delete-document/index.md
@@ -9,9 +9,9 @@ description: Collection:deleteDocument
 
 Delete a stored document, or all stored documents matching a search filter.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is deleted and it being reflected in the search layer (usually a couple of seconds). That means that a document that was just deleted may still be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is deleted and it being reflected in the search layer (usually a couple of seconds). That means that a document that was just deleted might still be returned by this function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/collection/scroll/index.md
+++ b/src/sdk/android/3/core-classes/collection/scroll/index.md
@@ -10,13 +10,13 @@ description: Collection:scroll
 Returns a [SearchResult](/sdk/android/3/core-classes/search-result/) object containing the next page of the scroll session, and the `scrollId` to be used in the next `scroll` action.
 A scroll session is always initiated by a `search` action and including the `scroll` argument; more information below.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned immediately by this function.
+:::
 
-<div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
-</div>
+:::info
+To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/collection/search/index.md
+++ b/src/sdk/android/3/core-classes/collection/search/index.md
@@ -9,9 +9,9 @@ description: Collection:search
 
 Executes a search on the collection.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned immediately by this function.
+:::
 
 ## Processing large data sets
 
@@ -44,9 +44,9 @@ See [`SearchResult.fetchNext`](/sdk/android/3/core-classes/search-result/fetch-n
 | `scroll`   | string  | Start a scroll session, with a time to live equals to this parameter's value following the [Elastisearch time format](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/common-options.html#time-units) | `undefined` |
 | `size`     | number  | Provide the maximum number of results of the request (used to paginate results)                                                                                                                                   | `10`        |
 
-<div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
-</div>
+:::info
+To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/document/set-content/index.md
+++ b/src/sdk/android/3/core-classes/document/set-content/index.md
@@ -10,9 +10,9 @@ description: Document:setContent
 Replaces the current content with new data.  
 This is a helper function returning a reference to itself so that you can easily chain calls.
 
-<div class="alert alert-info">
-Changes made by this function won't be applied until the <code>save</code> method is called
-</div>
+:::info
+Changes made by this function won't be applied until the `save` method is called
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/kuzzle/check-token/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/check-token/index.md
@@ -27,9 +27,9 @@ description: Kuzzle:checkToken
 
 Checks the validity of a JSON Web Token.
 
-<div class="alert alert-info">
+:::info
 This method is non-queuable, meaning that during offline mode, it will be discarded and the callback return an error.
-</div>
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/kuzzle/get-auto-refresh/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/get-auto-refresh/index.md
@@ -13,15 +13,12 @@ immediately after each write request, causing documents to be immediately visibl
 
 The `getAutoRefresh` function returns the current `autoRefresh` status for the given index.
 
-<div class="alert alert-warning">
-    <p>
-        A refresh operation comes with some performance costs.
-    </p>
-    <p>
-      While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid
-      using it in production or at least carefully monitor its implications before using it.
-    </p>
-</div>
+:::warning
+A refresh operation comes with some performance costs.
+
+While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid
+using it in production or at least carefully monitor its implications before using it.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/kuzzle/login/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/login/index.md
@@ -18,9 +18,9 @@ If the request succeeds but there is no token, then it means that the chosen str
 If the login attempt fails, the `loginAttempt` event is fired with the following response:
 `{ success: false, error: 'error message' }`
 
-<div class="alert alert-info">
-This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. [Learn more.](/core/1/guides/essentials/user-authentication/#local-strategy)
-</div>
+:::info
+This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/kuzzle/logout/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/logout/index.md
@@ -9,9 +9,9 @@ description: Kuzzle:logout
 
 Logs the user out.
 
-<div class="alert alert-info">
+:::info
 This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error.
-</div>
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/kuzzle/query/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/query/index.md
@@ -9,10 +9,10 @@ description: Kuzzle:query
 
 Base method used to send queries to Kuzzle, following the [API Documentation](/core/1/api).
 
-<div class="alert alert-warning">
-This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.<br/>
+:::warning
+This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.  
 Refer to Kuzzle's API Reference [here](/core/1/api)
-</div>
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/kuzzle/refresh-index/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/refresh-index/index.md
@@ -14,14 +14,13 @@ By default, this operation can take up to 1 second.
 Given an index, the `refresh` action forces a [`refresh`](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-refresh.html),
 on it, making the documents visible to search immediately.
 
-<div class="alert alert-warning">
-    A refresh operation comes with some performance costs.<br>
-    <br>
-    From <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-refresh.html">elasticsearch documentation</a>:
-    <div class="quote">
-    "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
-    </div>
-</div>
+:::warning
+A refresh operation comes with some performance costs.
+
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/kuzzle/set-auto-refresh/index.md
+++ b/src/sdk/android/3/core-classes/kuzzle/set-auto-refresh/index.md
@@ -13,15 +13,13 @@ immediately after each write request, causing documents to be immediately visibl
 
 Given an index, the `setAutoRefresh` function updates its `autoRefresh` status.
 
-<div class="alert alert-warning">
-    <p>
-        A refresh operation comes with some performance costs.
-    </p>
-    <p>
-        While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid
-        using it in production or at least carefully monitor its implications before using it.
-    </p>
-</div>
+:::warning
+A refresh operation comes with some performance costs.
+
+
+While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid
+using it in production or at least carefully monitor its implications before using it.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/memory-storage/sort/index.md
+++ b/src/sdk/android/3/core-classes/memory-storage/sort/index.md
@@ -10,9 +10,9 @@ description: MemoryStorage:sort
 Sorts and returns elements contained in a list, a set of unique values or a sorted set.
 By default, sorting is numeric and elements are compared by their value interpreted as double precision floating point number.
 
-<div class="alert alert-info"
+:::info
 While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the [query method](/sdk/android/3/core-classes/kuzzle/query)
-</div>
+:::
 
 [[_Redis documentation_]](https://redis.io/commands/sort)
 

--- a/src/sdk/android/3/core-classes/profile/add-policy/index.md
+++ b/src/sdk/android/3/core-classes/profile/add-policy/index.md
@@ -9,9 +9,9 @@ description: Profile:addPolicy
 
 Adds a role to the security profile.
 
-<div class="alert alert-info">
+:::info
 Updating a security profile will have no impact until the [save](/sdk/android/3/core-classes/profile/save/) method is called
-</div>
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/profile/save/index.md
+++ b/src/sdk/android/3/core-classes/profile/save/index.md
@@ -9,9 +9,9 @@ description: Profile:save
 
 Creates or replaces the profile in Kuzzle.
 
-<div class="alert alert-warning">
+:::warning
 Saving the object will return an error if the linked roles have not been previously created in Kuzzle.
-</div>
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/profile/set-content/index.md
+++ b/src/sdk/android/3/core-classes/profile/set-content/index.md
@@ -9,9 +9,9 @@ description: Profile:setContent
 
 Replaces the content of the `Profile` object.
 
-<div class="alert alert-info">
-Updating a profile will have no impact until the <code>save</code> method is called
-</div>
+:::info
+Updating a profile will have no impact until the `save` method is called
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/role/set-content/index.md
+++ b/src/sdk/android/3/core-classes/role/set-content/index.md
@@ -9,9 +9,9 @@ description: Role:setContent
 
 Replaces the content of the `Role` object.
 
-<div class="alert alert-info">
+:::info
 Updating a role content will have no impact until the [save](/sdk/android/3/core-classes/role/save/) method is called
-</div>
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/role/update/index.md
+++ b/src/sdk/android/3/core-classes/role/update/index.md
@@ -9,15 +9,12 @@ description: Role:update
 
 Updates the role object in Kuzzle.
 
-<div class="alert alert-warning">
-  <p>
-    Unlike a regular document update, this method will replace the whole role definition under the indexes node with the <code>updateContent</code> parameter.<br>
-    In other words, you always need to provide the complete role definition in the <code>updateContent</code> object.
-  </p>
-  <p>
-    This method has the same effect as calling [`setContent`](/sdk/android/3/core-classes/role/set-content/) followed by the [`save`](/sdk/android/3/core-classes/role/save/) method.
-  </p>
-</div>
+:::warning
+Unlike a regular document update, this method will replace the whole role definition under the indexes node with the `updateContent` parameter.  
+In other words, you always need to provide the complete role definition in the `updateContent` object.
+
+This method has the same effect as calling [setContent](/sdk/android/3/core-classes/role/set-content/) followed by the [save](/sdk/android/3/core-classes/role/save/) method.
+:::
 
 To get more information about Kuzzle permissions, please refer to our [permissions guide](/core/1/guides/essentials/security/#user-permissions).
 

--- a/src/sdk/android/3/core-classes/search-result/fetch-next/index.md
+++ b/src/sdk/android/3/core-classes/search-result/fetch-next/index.md
@@ -25,9 +25,13 @@ If the previous request was a search action which provided `from` and `size` arg
 
 The safest way to process all documents in a collection is to fetch them as a batch in order to avoid memory exhaustion and possibly hitting some hard limits<sup>\[1\]</sup> on the database layer.
 
-<div class="alert alert-warning">Make sure your first search request includes <code>size</code> and <code>scroll</code> parameters</div>
+:::warning
+Make sure your first search request includes the `size` and `scroll` parameters
+:::
 
-<div class="alert alert-info"><sup>\[1\]</sup> Elasticsearch limits the number of documents inside a single page to [10,000 by default](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/index-modules.html#dynamic-index-settings).</div>
+:::info
+<sup>\[1\]</sup> Elasticsearch limits the number of documents inside a single page to [10,000 by default](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/index-modules.html#dynamic-index-settings).
+:::
 
 ## Usage
 

--- a/src/sdk/android/3/core-classes/security/create-profile/index.md
+++ b/src/sdk/android/3/core-classes/security/create-profile/index.md
@@ -9,10 +9,10 @@ description: Security:createProfile
 
 Create a new profile in Kuzzle.
 
-<div class="alert alert-info">
-There is a small delay between profile creation and its availability in our search layer (usually a couple of seconds).
-That means that a profile that was just created might not be returned by the <code>searchProfiles</code> function at first.
-</div>
+:::info
+There is a small delay between profile creation and its availability in our search layer (usually a couple of seconds).  
+That means that a profile that was just created might not be immediately returned by the `searchProfiles` function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/security/create-restricted-user/index.md
+++ b/src/sdk/android/3/core-classes/security/create-restricted-user/index.md
@@ -10,10 +10,10 @@ description: Security:createRestrictedUser
 Create a new restricted user in Kuzzle.
 This function allows anonymous users to create a "restricted" user with predefined rights.
 
-<div class="alert alert-info">
-There is a small delay between user creation and its availability in our search layer (usually a couple of seconds).
-That means that a user that was just created may not be returned by the <code>searchUsers</code> function at first.
-</div>
+:::info
+There is a small delay between user creation and its availability in our search layer (usually a couple of seconds).  
+That means that a user that was just created may not be immediately returned by the `searchUsers` function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/security/create-role/index.md
+++ b/src/sdk/android/3/core-classes/security/create-role/index.md
@@ -9,10 +9,11 @@ description: Security:createRole
 
 Create a new role in Kuzzle.
 
-<div class="alert alert-info">
-There is a small delay between role creation and its availability in our search layer (usually a couple of seconds).
-That means that a role that was just created may not be returned by the <code>searchRole</code> function at first.
-</div>
+:::info
+There is a small delay between role creation and its availability in our search layer (usually a couple of seconds).  
+That means that a role that was just created may not be immediately returned by the `searchRole` function.
+:::
+
 ---
 
 ## createRole(id, content, [options], callback)

--- a/src/sdk/android/3/core-classes/security/create-user/index.md
+++ b/src/sdk/android/3/core-classes/security/create-user/index.md
@@ -9,10 +9,10 @@ description: Security:createUser
 
 Create a new user in Kuzzle.
 
-<div class="alert alert-info">
-There is a small delay between user creation and its availability in our search layer (usually a couple of seconds).
-That means that a user that was just created may not be returned by the <code>searchUsers</code> function at first.
-</div>
+:::info
+There is a small delay between user creation and its availability in our search layer (usually a couple of seconds).  
+That means that a user that was just created might not be returned immediately by the `searchUsers` function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/security/delete-profile/index.md
+++ b/src/sdk/android/3/core-classes/security/delete-profile/index.md
@@ -9,10 +9,10 @@ description: Security:deleteProfile
 
 Delete the provided profile.
 
-<div class="alert alert-info">
-There is a small delay between the time a profile is deleted and it being reflected in the search layer (usually a couple of seconds).
-That means that a profile that was just deleted may still be returned by the <code>searchProfiles</code> function at first.
-</div>
+:::info
+There is a small delay between the time a profile is deleted and it being reflected in the search layer (usually a couple of seconds).  
+That means that a profile that was just deleted might still be returned by the `searchProfiles` function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/security/delete-role/index.md
+++ b/src/sdk/android/3/core-classes/security/delete-role/index.md
@@ -9,10 +9,10 @@ description: Security:deleteRole
 
 Delete the provided role.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between the time a role is deleted and it being reflected in the search layer (usually a couple of seconds).
-That means that a role that was just deleted may still be returned by the <code>searchRoles</code> function at first.
-</div>
+That means that a role that was just deleted might still be returned by the `searchRoles` function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/security/delete-user/index.md
+++ b/src/sdk/android/3/core-classes/security/delete-user/index.md
@@ -9,10 +9,10 @@ description: Security:deleteUser
 
 Delete the provided user.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between the time a user is deleted and it being reflected in the search layer (usually a couple of seconds).
-That means that a user that has just been deleted may still be returned by the <code>searchUsers</code> function at first.
-</div>
+That means that a user that has just been deleted might still be returned by the `searchUsers` function.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/security/is-action-allowed/index.md
+++ b/src/sdk/android/3/core-classes/security/is-action-allowed/index.md
@@ -15,9 +15,9 @@ Specifies if an action is allowed, denied or conditional based on the rights pro
 
 An action is defined as a pair of action and controller (mandatory), plus an index and a collection(optional).
 
-<div class="alert alert-info">
-You can get the rights from Kuzzle by using [`Security.getUserRights`](/sdk/android/3/core-classes/security/get-user-rights/) and [`Kuzzle.getMyRights`](/sdk/android/3/core-classes/kuzzle/get-my-rights).
-</div>
+:::info
+You can get the rights from Kuzzle by using [Security.getUserRights](/sdk/android/3/core-classes/security/get-user-rights/) and [Kuzzle.getMyRights](/sdk/android/3/core-classes/kuzzle/get-my-rights).
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/security/search-users/index.md
+++ b/src/sdk/android/3/core-classes/security/search-users/index.md
@@ -30,9 +30,9 @@ Return users matching the given filter.
 | `scroll`   | string  | Start a scroll session, with a time to live equals to this parameter's value following the [Elastisearch time format](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/common-options.html#time-units) | `undefined` |
 | `size`     | number  |  Number of hits to return per result page                                                                                                                                                                         | `10`        |
 
-<div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
-</div>
+:::info
+To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/user/add-profile/index.md
+++ b/src/sdk/android/3/core-classes/user/add-profile/index.md
@@ -9,9 +9,9 @@ description: User:addProfile
 
 Replaces the security profile associated with the user.
 
-<div class="alert alert-info">
-Updating a user will have no impact until the [`create`](/sdk/android/3/core-classes/user/create/) or [`replace`](/sdk/android/3/core-classes/user/replace/) method is called
-</div>
+:::info
+Updating a user will have no impact until the [create](/sdk/android/3/core-classes/user/create/) or [replace](/sdk/android/3/core-classes/user/replace/) method is called
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/user/set-content/index.md
+++ b/src/sdk/android/3/core-classes/user/set-content/index.md
@@ -9,9 +9,9 @@ description: User:setContent
 
 Replaces the content of User.
 
-<div class="alert alert-info">
-Updating a user will have no impact until the [`create`](/sdk/android/3/core-classes/user/create/) or [`replace`](/sdk/android/3/core-classes/user/replace/) method is called
-</div>
+:::info
+Updating a user will have no impact until the [create](/sdk/android/3/core-classes/user/create/) or [replace](/sdk/android/3/core-classes/user/replace/) method is called.
+:::
 
 ---
 

--- a/src/sdk/android/3/core-classes/user/set-credentials/index.md
+++ b/src/sdk/android/3/core-classes/user/set-credentials/index.md
@@ -9,10 +9,11 @@ description: User:setCredentials
 
 Sets the user's credentials.
 
-<div class="alert alert-info">
-  Updating user credentials will have no impact until the [`create`](/sdk/android/3/core-classes/user/create/) method is called.<br />
-  The credentials to send depend on the authentication plugin and the strategy you want to create credentials for.
-</div>
+:::info
+Updating user credentials will have no impact until the [create](/sdk/android/3/core-classes/user/create/) method is called.  
+The credentials to send depend on the authentication plugin and the strategy you want to create credentials for.
+:::
+
 ---
 
 ## setCredentials(credentials)

--- a/src/sdk/android/3/core-classes/user/set-profiles/index.md
+++ b/src/sdk/android/3/core-classes/user/set-profiles/index.md
@@ -9,9 +9,10 @@ description: User:setProfiles
 
 Replaces the security profiles linked to the user.
 
-<div class="alert alert-info">
-Updating a user will have no impact until the <code>create</code> or <code>replace</code> method is called
-</div>
+:::info
+Updating a user will have no impact until the [create](/sdk/android/3/core-classes/user/create/) or [replace](/sdk/android/3/core-classes/user/replace/) method is called.
+:::
+
 ---
 
 ## setProfiles(profileIds)

--- a/src/sdk/cpp/1/controllers/collection/search-specifications/index.md
+++ b/src/sdk/cpp/1/controllers/collection/search-specifications/index.md
@@ -12,9 +12,9 @@ Searches collection specifications.
 There is a limit to how many items can be returned by a single search query.
 That limit is by default set at 10000, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-</div>
+:::info
+When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/cpp/1/core-classes/search-result/next/) rather than increasing the size parameter.
+:::
 
 ## Signature
 

--- a/src/sdk/cpp/1/controllers/document/search/index.md
+++ b/src/sdk/cpp/1/controllers/document/search/index.md
@@ -12,11 +12,9 @@ Searches documents.
 There is a limit to how many documents can be returned by a single search query.
 That limit is by default set at 10000 documents, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/cpp/1/core-classes/search-result/next/) rather than increasing the size parameter.
+:::
 
 ## Arguments
 

--- a/src/sdk/cpp/1/controllers/index/get-auto-refresh/index.md
+++ b/src/sdk/cpp/1/controllers/index/get-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html) action on Elasticsearch.
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
-  While forcing the autoRefresh can be convenient on a development or test environment,
-  we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::info
+A refresh operation comes with some performance costs.  
+While forcing the autoRefresh can be convenient on a development or test environment,
+we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
+:::
 
 ## Signature
 

--- a/src/sdk/cpp/1/controllers/index/refresh-internal/index.md
+++ b/src/sdk/cpp/1/controllers/index/refresh-internal/index.md
@@ -11,13 +11,12 @@ When writing or deleting security and internal documents (users, roles, profiles
 
 The `refreshInternal` action forces a [refresh](/sdk/cpp/1/controllers/index/), on the internal index, making the documents available to search immediately.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
-
-</div>
+From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+:::
 
 ## Signature
 

--- a/src/sdk/cpp/1/controllers/index/refresh/index.md
+++ b/src/sdk/cpp/1/controllers/index/refresh/index.md
@@ -9,13 +9,12 @@ description: Force Elasticsearch search index update
 
 When writing or deleting documents in Kuzzle, the update needs to be indexed before being available in search results.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
-
-</div>
+From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+:::
 
 ## Signature
 

--- a/src/sdk/cpp/1/controllers/index/set-auto-refresh/index.md
+++ b/src/sdk/cpp/1/controllers/index/set-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
-A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.  
 While forcing the autoRefresh can be convenient on a development or test environment,
 we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/cpp/1/controllers/server/get-config/index.md
+++ b/src/sdk/cpp/1/controllers/server/get-config/index.md
@@ -9,9 +9,9 @@ description: Returns the current Kuzzle configuration.
 
 Returns the current Kuzzle configuration.
 
-<div class="alert alert-warning">
-  This route should only be accessible to administrators, as it might return sensitive information about the backend.
-</div>
+:::warning
+This route should only be accessible to administrators, as it might return sensitive information about the backend.
+:::
 
 ## Signature
 

--- a/src/sdk/cpp/1/core-classes/kuzzle/query/index.md
+++ b/src/sdk/cpp/1/core-classes/kuzzle/query/index.md
@@ -9,9 +9,9 @@ description: Base method to send API query to Kuzzle
 
 Base method used to send queries to Kuzzle, following the [API Documentation](/core/1/api).
 
-<div class="alert alert-warning">
+:::warning
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/cpp/1/core-classes/search-result/next/index.md
+++ b/src/sdk/cpp/1/core-classes/search-result/next/index.md
@@ -23,14 +23,11 @@ Depending on the arguments given to the initial search, the `next` method will p
 
 If no policy is applicable, the `next` method throws an exception.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to use a <code>scroll</code> cursor.
-  </p>
-  <p>
-  It is also the only method that guarantees that all matching documents will be retrieved, without duplicates.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to use a scroll cursor (see the [scroll search option](/sdk/cpp/1/controllers/document/search/#arguments)).
+
+It is also the only method that guarantees that all matching documents will be retrieved, without duplicates.
+:::
 
 ## Usage with scroll
 
@@ -58,11 +55,9 @@ If the initial search is given `from` and `size` parameters, the `next` method w
 
 Because this method does not freeze the research between two calls, if updates are applied to the database between two calls, it is possible to miss documents and/or to get duplicates between search pages.
 
-<div class="alert alert-info">
-  <p>
-    NB: It is not possible to retrieve more than 10000 items using this method. Beyond that limit, any call to <code>next</code> will throw an Exception.
-  </p>
-</div>
+:::info
+It is not possible to retrieve more than 10000 items using this method. Beyond that limit, any call to `next` will throw an Exception.
+:::
 
 <<< ./snippets/fromsize.cpp
 

--- a/src/sdk/cpp/1/essentials/getting-started/index.md
+++ b/src/sdk/cpp/1/essentials/getting-started/index.md
@@ -17,13 +17,16 @@ You will learn :
 - how to **store** documents
 - how to to **subcribe** to real-time notifications
 
-<div class="alert alert-success">
+:::success
 Before proceeding, please make sure your system meets the following requirements :
 
 - A C++ compiler that supports C++ 11 sush as: **gcc** version 4.5 or higher
 - A running instance of Kuzzle Server ([Kuzzle installation guide](/core/1/guides/essentials/installing-kuzzle/))
+:::
 
-</div>
+:::info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)! 
+:::
 
 ## Installation
 
@@ -135,10 +138,6 @@ Now, you know how to:
 
 - Create realtime filters
 - Subscribe to notifications
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
 
 ## Where do we go from here?
 

--- a/src/sdk/go/1/controllers/collection/search-specifications/index.md
+++ b/src/sdk/go/1/controllers/collection/search-specifications/index.md
@@ -14,9 +14,9 @@ Searches collection specifications.
 There is a limit to how many items can be returned by a single search query.
 That limit is by default set at 10000, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-</div>
+:::info
+When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/go/1/core-structs/search-result/#methods) rather than increasing the size parameter.
+:::
 
 ## Arguments
 

--- a/src/sdk/go/1/controllers/document/search/index.md
+++ b/src/sdk/go/1/controllers/document/search/index.md
@@ -12,11 +12,9 @@ Searches documents.
 There is a limit to how many documents can be returned by a single search query.
 That limit is by default set at 10000 documents, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/go/1/core-structs/search-result/#methods) rather than increasing the size parameter.
+:::
 
 ## Arguments
 

--- a/src/sdk/go/1/controllers/index/get-auto-refresh/index.md
+++ b/src/sdk/go/1/controllers/index/get-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.  
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.  
-  While forcing the autoRefresh can be convenient on a development or test environment,  
-  we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::info
+A refresh operation comes with some performance costs.  
+While forcing the autoRefresh can be convenient on a development or test environment,  
+we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
+:::
 
 ## Signature
 

--- a/src/sdk/go/1/controllers/index/refresh/index.md
+++ b/src/sdk/go/1/controllers/index/refresh/index.md
@@ -9,13 +9,12 @@ description: Force Elasticsearch search index update
 
 When writing or deleting documents in Kuzzle, the update needs to be indexed before being available in search results.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
-
-</div>
+From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+:::
 
 ## Signature
 

--- a/src/sdk/go/1/controllers/index/set-auto-refresh/index.md
+++ b/src/sdk/go/1/controllers/index/set-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.  
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
+:::info
 A refresh operation comes with some performance costs.  
 While forcing the autoRefresh can be convenient on a development or test environment,  
 we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/go/1/controllers/server/get-config/index.md
+++ b/src/sdk/go/1/controllers/server/get-config/index.md
@@ -11,9 +11,9 @@ description: Returns the current Kuzzle configuration.
 
 Returns the current Kuzzle configuration.
 
-<div class="alert alert-warning">
-  This route should only be accessible to administrators, as it might return sensitive information about the backend.
-</div>
+:::warning
+This route should only be accessible to administrators, as it might return sensitive information about the backend.
+:::
 
 ## Arguments
 

--- a/src/sdk/go/1/core-structs/kuzzle/query/index.md
+++ b/src/sdk/go/1/core-structs/kuzzle/query/index.md
@@ -9,9 +9,9 @@ description: Base method to send API query to Kuzzle
 
 Base method used to send queries to Kuzzle, following the [API Documentation](/core/1/api).
 
-<div class="alert alert-warning">
+:::warning
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/go/1/core-structs/search-result/index.md
+++ b/src/sdk/go/1/core-structs/search-result/index.md
@@ -28,7 +28,7 @@ The `SearchResult` struct exposes an unique `Next` method, which returns a new `
 Next() (*SearchResult, error)
 ```
 
-## Behaviour of the next method
+## Behavior of the next method
 
 In order to be able to compute the next search page, some initial conditions must be met.
 
@@ -36,14 +36,11 @@ Depending on the arguments given to the initial search, thhe `Next` method will 
 
 If no policy is applicable, the `next` method will throw an exception.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to use a <code>scroll</code> cursor.
-  </p>
-  <p>
-  It is also the only method that garantees all matching documents will be retrieved and no duplicates will be included.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to use a scroll cursor.
+
+It is also the only method that garantees all matching documents will be retrieved and no duplicates will be included.
+:::
 
 ### 1. scroll
 
@@ -69,11 +66,9 @@ If the initial search is given some `from` and `size` parameters, the `Next` met
 
 Because this method does not freeze the research between two calls, if some updates are applied to the database between two calls, it is possible to miss some documents and/or to get some duplicates between search pages.
 
-<div class="alert alert-info">
-  <p>
-    NB: It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to <code>Next</code> will return an error
-  </p>
-</div>
+:::info
+It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to `Next` will return an error
+:::
 
 ## Usage
 

--- a/src/sdk/go/1/essentials/getting-started/index.md
+++ b/src/sdk/go/1/essentials/getting-started/index.md
@@ -18,6 +18,10 @@ Before proceeding, please make sure your system meets the following requirements
 - A running Kuzzle server ([Kuzzle installation guide](/core/1/guides/essentials/installing-kuzzle/))</li>
   :::
 
+::: info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
+
 ## Installation
 
 To easily install the Go SDK:
@@ -102,10 +106,6 @@ Now, you know how to:
 
 - Create realtime filters
 - Subscribe to notifications
-
-::: info
-Having trouble? Get in touch with us on [Gitter!](https://gitter.im/kuzzleio/kuzzle) We're happy to help.
-:::
 
 ## Where do we go from here?
 

--- a/src/sdk/go/2/controllers/collection/search-specifications/index.md
+++ b/src/sdk/go/2/controllers/collection/search-specifications/index.md
@@ -14,9 +14,9 @@ Searches collection specifications.
 There is a limit to how many items can be returned by a single search query.
 That limit is by default set at 10000, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-</div>
+:::info
+When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/go/2/core-structs/search-result/#methods) rather than increasing the size parameter.
+:::
 
 ## Arguments
 

--- a/src/sdk/go/2/controllers/document/search/index.md
+++ b/src/sdk/go/2/controllers/document/search/index.md
@@ -12,11 +12,9 @@ Searches documents.
 There is a limit to how many documents can be returned by a single search query.
 That limit is by default set at 10000 documents, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/go/2/core-structs/search-result/#methods) rather than increasing the size parameter.
+:::
 
 ## Arguments
 

--- a/src/sdk/go/2/controllers/index/get-auto-refresh/index.md
+++ b/src/sdk/go/2/controllers/index/get-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.  
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.  
-  While forcing the autoRefresh can be convenient on a development or test environment,  
-  we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::info
+A refresh operation comes with some performance costs.  
+While forcing the autoRefresh can be convenient on a development or test environment,  
+we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
+:::
 
 ## Signature
 

--- a/src/sdk/go/2/controllers/index/refresh/index.md
+++ b/src/sdk/go/2/controllers/index/refresh/index.md
@@ -9,13 +9,12 @@ description: Force Elasticsearch search index update
 
 When writing or deleting documents in Kuzzle, the update needs to be indexed before being available in search results.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
-
-</div>
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+:::
 
 ## Signature
 

--- a/src/sdk/go/2/controllers/index/set-auto-refresh/index.md
+++ b/src/sdk/go/2/controllers/index/set-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.  
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
+:::info
 A refresh operation comes with some performance costs.  
 While forcing the autoRefresh can be convenient on a development or test environment,  
 we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/go/2/controllers/server/get-config/index.md
+++ b/src/sdk/go/2/controllers/server/get-config/index.md
@@ -11,9 +11,9 @@ description: Returns the current Kuzzle configuration.
 
 Returns the current Kuzzle configuration.
 
-<div class="alert alert-warning">
-  This route should only be accessible to administrators, as it might return sensitive information about the backend.
-</div>
+:::warning
+This route should only be accessible to administrators, as it might return sensitive information about the backend.
+:::
 
 ## Arguments
 

--- a/src/sdk/go/2/core-structs/kuzzle/query/index.md
+++ b/src/sdk/go/2/core-structs/kuzzle/query/index.md
@@ -9,9 +9,9 @@ description: Base method to send API query to Kuzzle
 
 Base method used to send queries to Kuzzle, following the [API Documentation](/core/1/api).
 
-<div class="alert alert-warning">
+:::warning
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/go/2/core-structs/search-result/index.md
+++ b/src/sdk/go/2/core-structs/search-result/index.md
@@ -36,14 +36,11 @@ Depending on the arguments given to the initial search, thhe `Next` method will 
 
 If no policy is applicable, the `next` method will throw an exception.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to use a <code>scroll</code> cursor.
-  </p>
-  <p>
-  It is also the only method that garantees all matching documents will be retrieved and no duplicates will be included.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to use a scroll cursor.
+
+It is also the only method that garantees all matching documents will be retrieved and no duplicates will be included.
+:::
 
 ### 1. scroll
 
@@ -69,11 +66,9 @@ If the initial search is given some `from` and `size` parameters, the `Next` met
 
 Because this method does not freeze the research between two calls, if some updates are applied to the database between two calls, it is possible to miss some documents and/or to get some duplicates between search pages.
 
-<div class="alert alert-info">
-  <p>
-    NB: It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to <code>Next</code> will return an error
-  </p>
-</div>
+:::info
+It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to `Next` will return an error
+:::
 
 ## Usage
 

--- a/src/sdk/go/2/essentials/getting-started/index.md
+++ b/src/sdk/go/2/essentials/getting-started/index.md
@@ -18,6 +18,10 @@ Before proceeding, please make sure your system meets the following requirements
 - A running Kuzzle server ([Kuzzle installation guide](/core/1/guides/essentials/installing-kuzzle/))</li>
   :::
 
+::: info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
+
 ## Installation
 
 To easily install the Go SDK:
@@ -102,10 +106,6 @@ Now, you know how to:
 
 - Create realtime filters
 - Subscribe to notifications
-
-::: info
-Having trouble? Get in touch with us on [Gitter!](https://gitter.im/kuzzleio/kuzzle) We're happy to help.
-:::
 
 ## Where do we go from here?
 

--- a/src/sdk/java/1/controllers/document/search/index.md
+++ b/src/sdk/java/1/controllers/document/search/index.md
@@ -12,11 +12,9 @@ Searches documents.
 There is a limit to how many documents can be returned by a single search query.
 That limit is by default set at 10000 documents, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/java/1/core-classes/search-result/#methods) rather than increasing the size parameter.
+:::
 
 ## Arguments
 

--- a/src/sdk/java/1/controllers/index/get-auto-refresh/index.md
+++ b/src/sdk/java/1/controllers/index/get-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.  
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.  
-  While forcing the autoRefresh can be convenient on a development or test environment,  
-  we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::info
+A refresh operation comes with some performance costs.  
+While forcing the autoRefresh can be convenient on a development or test environment,  
+we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
+:::
 
 ## Signature
 

--- a/src/sdk/java/1/controllers/index/refresh-internal/index.md
+++ b/src/sdk/java/1/controllers/index/refresh-internal/index.md
@@ -11,13 +11,13 @@ When writing or deleting security and internal documents (users, roles, profiles
 
 The `refreshInternal` action forces a [refresh](/sdk/java/1/controllers/index/refresh/), on the internal index, making the documents available to search immediately.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
 
-</div>
+:::
 
 ## Arguments
 

--- a/src/sdk/java/1/controllers/index/refresh/index.md
+++ b/src/sdk/java/1/controllers/index/refresh/index.md
@@ -9,13 +9,13 @@ description: Force Elasticsearch search index update
 
 When writing or deleting documents in Kuzzle, the update needs to be indexed before being available in search results.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
 
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/java/1/controllers/index/set-auto-refresh/index.md
+++ b/src/sdk/java/1/controllers/index/set-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.  
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
+:::info
 A refresh operation comes with some performance costs.  
 While forcing the autoRefresh can be convenient on a development or test environment,  
 we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/java/1/controllers/server/get-config/index.md
+++ b/src/sdk/java/1/controllers/server/get-config/index.md
@@ -11,9 +11,9 @@ description: Returns the current Kuzzle configuration.
 
 Returns the current Kuzzle configuration.
 
-<div class="alert alert-warning">
-  This route should only be accessible to administrators, as it might return sensitive information about the backend.
-</div>
+:::warning
+This route should only be accessible to administrators, as it might return sensitive information about the backend.
+:::
 
 ## Arguments
 

--- a/src/sdk/java/1/core-classes/kuzzle/query/index.md
+++ b/src/sdk/java/1/core-classes/kuzzle/query/index.md
@@ -9,9 +9,9 @@ description: Base method to send API query to Kuzzle
 
 Base method used to send queries to Kuzzle, following the [API Documentation](/core/1/api).
 
-<div class="alert alert-warning">
+:::warning
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.
-</div>
+:::
 
 ## Signature
 

--- a/src/sdk/java/1/core-classes/search-result/index.md
+++ b/src/sdk/java/1/core-classes/search-result/index.md
@@ -36,14 +36,11 @@ Depending on the arguments given to the initial search, thhe `next` method will 
 
 If no policy is applicable, the `next` method will throw an exception.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to use a <code>scroll</code> cursor.
-  </p>
-  <p>
-  It is also the only method that garantees all matching documents will be retrieved and no duplicates will be included.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to use a scroll cursor.
+
+It is also the only method that garantees all matching documents will be retrieved and no duplicates will be included.
+:::
 
 ### 1. scroll
 
@@ -69,11 +66,9 @@ If the initial search is given some `from` and `size` parameters, the `next` met
 
 Because this method does not freeze the research between two calls, if some updates are applied to the database between two calls, it is possible to miss some documents and/or to get some duplicates between search pages.
 
-<div class="alert alert-info">
-  <p>
-    NB: It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to <code>next</code> will throw an Exception.
-  </p>
-</div>
+:::info
+It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to `next` will throw an Exception.
+:::
 
 ## Usage
 

--- a/src/sdk/java/1/essentials/getting-started/index.md
+++ b/src/sdk/java/1/essentials/getting-started/index.md
@@ -19,6 +19,11 @@ Before proceeding, please make sure your system meets the following requirements
 
 :::
 
+
+::: info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
+
 ## Installation
 
 ### Maven and Gradle
@@ -118,10 +123,6 @@ Now, you know how to:
 
 - Create realtime filters
 - Subscribe to notifications
-
-::: info
-Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle) ! We're happy to help.
-:::
 
 ## Where do we go from here?
 

--- a/src/sdk/js/5/core-classes/collection-mapping/constructor/index.md
+++ b/src/sdk/js/5/core-classes/collection-mapping/constructor/index.md
@@ -13,9 +13,9 @@ This means that, by default, you won't be able to exploit the full capabilities 
 
 The CollectionMapping object allows you to get the current mapping in a collection and to modify it if necessary.
 
-<div class="alert alert-info">
-Once a field mapping has been set, it cannot be removed without reconstructing the collection.
-</div>
+:::info
+Once a field mapping has been set, it cannot be removed without recreating the collection.
+:::
 
 ---
 

--- a/src/sdk/js/6/controllers/collection/search-specifications/index.md
+++ b/src/sdk/js/6/controllers/collection/search-specifications/index.md
@@ -14,9 +14,9 @@ Searches collection specifications.
 There is a limit to how many items can be returned by a single search query.
 That limit is by default set at 10000, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-</div>
+:::info
+When processing a large number of items (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/js/6/core-classes/search-result/next/) rather than increasing the size parameter.
+:::
 
 <br/>
 

--- a/src/sdk/js/6/controllers/document/search/index.md
+++ b/src/sdk/js/6/controllers/document/search/index.md
@@ -12,11 +12,9 @@ Searches documents.
 There is a limit to how many documents can be returned by a single search query.
 That limit is by default set at 10000 documents, and you can't get over it even with the from and size pagination options.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using <code>SearchResult.next</code> rather than increasing the size parameter.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to paginate the results using [SearchResult.next](/sdk/js/6/core-classes/search-result/next/) rather than increasing the size parameter.
+:::
 
 <br/>
 

--- a/src/sdk/js/6/controllers/index/get-auto-refresh/index.md
+++ b/src/sdk/js/6/controllers/index/get-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request triggers a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html) action in Elasticsearch.
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
-  While forcing the autoRefresh can be convenient on a development or test environment,
-  we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::info
+A refresh operation comes with some performance costs.
+While forcing the autoRefresh can be convenient on a development or test environment,
+we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
+:::
 
 <br/>
 

--- a/src/sdk/js/6/controllers/index/refresh-internal/index.md
+++ b/src/sdk/js/6/controllers/index/refresh-internal/index.md
@@ -11,13 +11,13 @@ When writing or deleting security and internal documents (users, roles, profiles
 
 The `refreshInternal` action forces a [refresh](//sdk/js/6/controllers/index/refresh), on the internal index, making the documents available to search immediately.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
 
-</div>
+:::
 
 ## Arguments
 

--- a/src/sdk/js/6/controllers/index/refresh/index.md
+++ b/src/sdk/js/6/controllers/index/refresh/index.md
@@ -9,13 +9,13 @@ description: Forces an Elasticsearch search index update
 
 When writing or deleting documents in Kuzzle, the update needs to be indexed before being available in search results.
 
-<div class="alert alert-info">
-  A refresh operation comes with some performance costs.
+:::info
+A refresh operation comes with some performance costs.
 
-From [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
-"While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
 
-</div>
+:::
 
 <br/>
 

--- a/src/sdk/js/6/controllers/index/set-auto-refresh/index.md
+++ b/src/sdk/js/6/controllers/index/set-auto-refresh/index.md
@@ -13,11 +13,11 @@ Each index has an autorefresh flag.
 When set to true, each write request trigger a [refresh](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html) action on Elasticsearch.
 Without a refresh after a write request, the documents may not be immediately visible in search.
 
-<div class="alert alert-info">
+:::info
 A refresh operation comes with performance costs.
 While forcing the autoRefresh can be convenient on a development or test environment,
 we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
-</div>
+:::
 
 <br/>
 

--- a/src/sdk/js/6/controllers/server/get-config/index.md
+++ b/src/sdk/js/6/controllers/server/get-config/index.md
@@ -9,9 +9,9 @@ description: Returns the current Kuzzle configuration.
 
 Returns the current Kuzzle configuration.
 
-<div class="alert alert-warning">
-  This route should only be accessible to administrators, as it might return sensitive information about the backend.
-</div>
+:::warning
+This route should only be accessible to administrators, as it might return sensitive information about the backend.
+:::
 
 <br/>
 

--- a/src/sdk/js/6/core-classes/kuzzle/query/index.md
+++ b/src/sdk/js/6/core-classes/kuzzle/query/index.md
@@ -9,9 +9,9 @@ description: Base method to send API query to Kuzzle
 
 Base method used to send queries to Kuzzle, following the [API Documentation](/core/1/api).
 
-<div class="alert alert-warning">
+:::warning
 This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.
-</div>
+:::
 
 ## Arguments
 

--- a/src/sdk/js/6/core-classes/search-result/next/index.md
+++ b/src/sdk/js/6/core-classes/search-result/next/index.md
@@ -24,14 +24,11 @@ Depending on the arguments given to the initial search, thhe `next` method will 
 
 If no policy is applicable, the `next` method will throw an exception.
 
-<div class="alert alert-info">
-  <p>
-  When processing a large number of documents (i.e. more than 1000), it is advised to use a <code>scroll</code> cursor.
-  </p>
-  <p>
-  It is also the only method that garantees all matching documents will be retrieved and no duplicates will be included.
-  </p>
-</div>
+:::info
+When processing a large number of documents (i.e. more than 1000), it is advised to use a scroll cursor.
+
+It is also the only method guaranteeing that all matching documents will be retrieved and no duplicates will be included.
+:::
 
 ## Usage with scroll
 
@@ -59,10 +56,8 @@ If the initial search is given some `from` and `size` parameters, the `next` met
 
 Because this method does not freeze the research between two calls, if some updates are applied to the database between two calls, it is possible to miss some documents and/or to get some duplicates between search pages.
 
-<div class="alert alert-info">
-  <p>
-    NB: It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to <code>next</code> will throw an Exception.
-  </p>
-</div>
+:::info
+It is not possible to retrieve more than 10000 items using this method. Above that limit, any call to `next` will throw an Exception.
+:::
 
 <<< ./snippets/fromsize.js

--- a/src/sdk/js/6/getting-started/node-js/index.md
+++ b/src/sdk/js/6/getting-started/node-js/index.md
@@ -15,11 +15,16 @@ You are going to write an application that **stores** documents in Kuzzle Server
 
 To follow this tutorial, you must have a Kuzzle Server up and running. Follow these instructions if this is not already the case: [Running Kuzzle](/core/1/guides/getting-started/running-kuzzle/).
 
+
+:::info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
+
 ## Explore the SDK
 
 It's time to get started with the [Kuzzle Javascript SDK](/sdk/js/6). This section, explains you how to store a document and subscribe to notifications in Kuzzle using the Javascript SDK.
 
-Before proceeding, please make sure your system has **Node.js** version 8 or higher (<a href="https://nodejs.org/en/download/">instructions here</a>) installed.
+Before proceeding, please make sure your system has **Node.js** version 8 or higher ([download page](https://nodejs.org/en/download/)) installed.
 
 ## Prepare your environment
 
@@ -31,18 +36,18 @@ cd "kuzzle-playground"
 npm install kuzzle-sdk
 ```
 
-<div class="alert alert-info">
+:::info
 If you are performing a clean install you might get some `UNMET PEER DEPENDENCY` warnings, these are safe to ignore as they refer to optional dependencies.
-</div>
+:::
 
 Then, create an `init.js` file and start by adding the code below.
 This loads the SDK and connects it to a Kuzzle instance using the WebSocket protocol.
 
 <<< ./snippets/load-sdk.js
 
-<div class="alert alert-info">
-Replace 'kuzzle' which is the Kuzzle server hostname with 'localhost' or the hostname where your Kuzzle server is running.
-</div>
+:::info
+Replace 'kuzzle' which is the Kuzzle server hostname with 'localhost' or with the host name where your Kuzzle server is running.
+:::
 
 Next, add a listener to be notified in case of a connection error:
 
@@ -81,9 +86,9 @@ The console should output the following message:
 nyc-open-data/yellow-taxi ready!
 ```
 
-<div class="alert alert-success">
+:::success
 Congratulations! You are now ready to say Hello to the World!
-</div>
+:::
 
 ## Create your first "Hello World" document
 
@@ -104,14 +109,10 @@ Run the code with Node.js:
 node create.js
 ```
 
-<div class="alert alert-success">
-You have now successfully stored your first document into Kuzzle. Click [here](/core/1/guides/essentials/admin-console/) to see how you can use the
-   <a href="http://console.kuzzle.io" target="_blank"><strong>Kuzzle Admin Console</strong></a> to browse your collection and confirm that your document was saved.
-</div>
+:::success
+You have now successfully stored your first document into Kuzzle. You can now open an [Admin Console](http://console.kuzzle.io) to browse your collection and confirm that your document was saved.
+:::
 
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
 
 ## Subscribe to realtime document notifications (pub/sub)
 
@@ -142,9 +143,9 @@ Check the `subscribe.js` terminal: a new message is printed everytime a document
 New driver Sirkis with id AWccRe3-DfukVhSzMdUo has B license.
 ```
 
-<div class="alert alert-success">
+:::success
 Congratulations! You have just set up your first pub/sub communication!
-</div>
+:::
 
 ## Where do we go from here?
 

--- a/src/sdk/js/6/getting-started/raw-web/index.md
+++ b/src/sdk/js/6/getting-started/raw-web/index.md
@@ -12,9 +12,13 @@ This tutorial explains how to use **Kuzzle** with the **Javascript SDK** in a **
 
 To follow this tutorial, you must have a Kuzzle Server up and running (you'll need to know the hostname of the machine running it). If this is not already the case, take a look at [how to run Kuzzle](/core/1/guides/getting-started/running-kuzzle/).
 
-Before proceeding, make sure your system has **Node.js** version 8 or higher (<a href="https://nodejs.org/en/download/">instructions here</a>) installed.
+Before proceeding, make sure your system has **Node.js** version 8 or higher ([download page](https://nodejs.org/en/download/)) installed.
 
 In this tutorial, you'll learn how to **store** a document and **subscribe** to notifications in Kuzzle using the Javascript SDK.
+
+:::info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
 
 ## Prepare your environment
 
@@ -25,9 +29,9 @@ mkdir "kuzzle-playground"
 cd "kuzzle-playground"
 ```
 
-<div class="alert alert-info">
-If you are performing a clean install you might get some <code>UNMET PEER DEPENDENCY</code> warnings, these are safe to ignore as they refer to optional dependencies.
-</div>
+:::info
+If you are performing a clean install you might get some `UNMET PEER DEPENDENCY` warnings, these are safe to ignore as they refer to optional dependencies.
+:::
 
 Then, create an `index.html` file with the following structure:
 
@@ -48,11 +52,11 @@ Then, create an `index.html` file with the following structure:
 </html>
 ```
 
-<div class="alert alert-info">
+:::info
 If you are using Internet Explorer (not Edge), you are responsible of installing a Promise polyfill, which enables IE to support
-Javascript <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promises</a>.
-Our advice is to use <a href="http://bluebirdjs.com/docs/getting-started.html">Bluebird</a>, as shown in the code example above (refer to the commented lines in the <code>head</code> tag).
-</div>
+Javascript [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).  
+Our advice is to use [Bluebird](http://bluebirdjs.com/docs/getting-started.html), as shown in the code example above (refer to the commented lines in the `head` tag).
+:::
 
 Then, add the code below in the `body` tag.
 This loads the SDK and connects it to a Kuzzle instance using the WebSocket protocol. If an error occurs, it is displayed
@@ -60,9 +64,9 @@ in the console. Once the connection is established, a success message is display
 
 <<< ./snippets/load-sdk.html
 
-<div class="alert alert-info">
-Replace <code>kuzzle</code> with <code>localhost</code> or the hostname where your Kuzzle server is running.
-</div>
+:::info
+Replace `kuzzle` with <code>localhost</code> or with the host name where your Kuzzle server is running.
+:::
 
 Now you have to add the code that will access Kuzzle to create a new index `nyc-open-data` and a new collection `yellow-taxi`
 that you will use to store data later on. Make sure the code inside your `body` tag looks like the following:
@@ -86,14 +90,14 @@ Successfully connected to Kuzzle
 nyc-open-data/yellow-taxi ready!
 ```
 
-<div class="alert alert-success">
+:::success
 Congratulations! You are now ready to say Hello to the World!
-</div>
+:::
 
-<div class="alert alert-info">
+:::info
 If you reload the page, you should see an error in the console. This is OK, since Kuzzle is just refusing to create
-the <code>nyc-open-data</code> index as it already exists.
-</div>
+the `nyc-open-data` index as it already exists.
+:::
 
 ## Create your first "Hello World" document
 
@@ -119,13 +123,10 @@ Successfully connected to Kuzzle
 New document successfully created!
 ```
 
-<div class="alert alert-success">
-You have now successfully stored your first document into Kuzzle. Click [here](/core/1/guides/essentials/admin-console/) to see how you can use the <strong>Kuzzle Admin Console</strong> to browse your collection and confirm that your document was saved.
-</div>
+:::success
+You have now successfully stored your first document into Kuzzle. Check our [Admin Console Guide](/core/1/guides/essentials/admin-console/) to see how to browse your collection and confirm that your document was saved.
+:::
 
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
 
 ## Subscribe to realtime document notifications (pub/sub)
 
@@ -153,9 +154,9 @@ This creates a new document in Kuzzle which, in turn, triggers a [document notif
 New driver Sirkis with id AWccRe3-DfukVhSzMdUo has B license.
 ```
 
-<div class="alert alert-success">
+:::success
 Congratulations! You have just set up your first pub/sub communication!
-</div>
+:::
 
 ## Where do we go from here?
 

--- a/src/sdk/js/6/getting-started/webpack/index.md
+++ b/src/sdk/js/6/getting-started/webpack/index.md
@@ -11,6 +11,10 @@ order: 200
 In this tutorial you will learn how to install, run and use **Kuzzle** with the **Javascript SDK** in the browser using **Webpack**.
 We will walk you through creating scripts that can **store** documents in Kuzzle and subscribe to **notifications** for each new document created.
 
+:::info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)!
+:::
+
 ## Running Kuzzle
 
 Before going through this tutorial, you should have a Kuzzle server running. Please refer to the [Running Kuzzle Tutorial](/core/1/guides/getting-started/running-kuzzle/) if you don't have one yet.
@@ -19,15 +23,15 @@ Before going through this tutorial, you should have a Kuzzle server running. Ple
 
 It's time to play with the [Kuzzle Javscript SDK](/sdk/js/6). In this section, we will store a document and subscribe to notifications in Kuzzle using the Javascript SDK in your browser.
 
-Before proceeding, please make sure your system has **Node.js** version 8 or higher (<a href="https://nodejs.org/en/download/">instructions here</a>) installed.
+Before proceeding, please make sure your system has **Node.js** version 8 or higher ([download page](https://nodejs.org/en/download/)) installed.
 
 ## Including the Kuzzle SDK in a Webpack project
 
-<div class="alert alert-info">
-    This section explains how to use the Kuzzle SDK within an existing Webpack project.
-    If you don't have your project up and running yet and want to learn how to leverage Webpack to build it, please refer to
-    the <a href="https://webpack.js.org/guides/getting-started/">official Webpack Getting Started page</a>.
-</div>
+:::info
+This section explains how to use the Kuzzle SDK within an existing Webpack project.
+If you don't have your project up and running yet and want to learn how to leverage Webpack to build it, please refer to
+the [official Webpack Getting Started page](https://webpack.js.org/guides/getting-started/).
+:::
 
 In your terminal, go to the root of your front-end project using Webpack and type
 
@@ -35,9 +39,9 @@ In your terminal, go to the root of your front-end project using Webpack and typ
 npm install kuzzle-sdk
 ```
 
-<div class="alert alert-info">
-If you are performing a clean install you might see some <code>unmet peer dependency</code> warnings, these are safe to ignore as they refer to optional dependencies.
-</div>
+:::info
+If you are performing a clean install you might see some `UNMET PEER DEPENDENCY` warnings, these are safe to ignore as they refer to optional dependencies.
+:::
 
 Then, create a `init-kuzzle.js` file and start by adding the code below. This will load the Kuzzle Javascript SDK:
 
@@ -124,13 +128,9 @@ Your console should output the following message:
 nyc-open-data/yellow-taxi ready!
 ```
 
-<div class="alert alert-success">
+:::success
 Congratulations! You are now ready to say Hello to the World!
-</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::
 
 ## Create your first document
 
@@ -172,16 +172,9 @@ Now, click the button and check your console for a message like the following:
 New document successfully created!
 ```
 
-<div class="alert alert-success">
-    You have now successfully stored your first document into Kuzzle. Click
-    [here](/core/1/guides/essentials/admin-console/) to see how you can use the
-    <strong><a href="http://console.kuzzle.io/">Kuzzle Admin Console</a></strong> to browse your collection and
-    confirm that your document was saved.
-</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::success
+You have now successfully stored your first document into Kuzzle. You can now open an [Admin Console](http://console.kuzzle.io) to browse your collection and confirm that your document was saved.
+:::
 
 ## Subscribe to realtime document notifications (pub/sub)
 
@@ -216,13 +209,9 @@ New driver Sirkis with id <driver-id> has B license.
 
 In place of `<driver-id>` you'll see the ID that Kuzzle automatically generated for the document.
 
-<div class="alert alert-success">
+:::success
 Congratulations! You have just choreographed your first pub/sub pattern!
-</div>
-
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::
 
 ## Where do we go from here?
 

--- a/src/sdk/js/6/protocols/http/introduction/index.md
+++ b/src/sdk/js/6/protocols/http/introduction/index.md
@@ -10,11 +10,8 @@ order: 0
 
 The Http protocol can be used by an instance of the SDK to communicate with your Kuzzle server.
 
-<div class="alert alert-info">
-  <p>
-  This protocol does not allow to use the [real-time notifications](/sdk/js/6/essentials/realtime-notifications/).
-  </p>
-  <p>
-  You have to use [WebSocket](/sdk/js/6/protocols/websocket) or [SocketIO](/sdk/js/6/protocols/socketio) protocol instead.
-  </p>
-</div>
+:::info
+This protocol does not allow to use the [real-time notifications](/sdk/js/6/essentials/realtime-notifications/).
+
+If you need real-time features, then you have to use either [WebSocket](/sdk/js/6/protocols/websocket) or [SocketIO](/sdk/js/6/protocols/socketio) protocols.
+:::

--- a/src/sdk/js/6/protocols/socketio/introduction/index.md
+++ b/src/sdk/js/6/protocols/socketio/introduction/index.md
@@ -11,8 +11,6 @@ order: 0
 The SocketIO protocol can be used by an instance of the SDK to communicate with your Kuzzle server.
 This protocol allows you to use all the features of Kuzzle, including [real-time notifications](/sdk/js/6/essentials/realtime-notifications/).
 
-<div class="alert alert-info">
-  <p>
-  The SocketIO protocol is used for websocket compatibility with older browsers. It is preferable to use the [WebSocket](/sdk/js/6/protocols/websocket) protocol when possible.
-  </p>
-</div>
+:::info
+The SocketIO protocol is used for WebSocket compatibility with older browsers. It is preferable to use the [WebSocket](/sdk/js/6/protocols/websocket) protocol when possible.
+:::

--- a/src/sdk/php/3/core-classes/collection-mapping/constructor/index.md
+++ b/src/sdk/php/3/core-classes/collection-mapping/constructor/index.md
@@ -13,9 +13,9 @@ This means that, by default, you won't be able to exploit the full capabilities 
 
 The CollectionMapping object allows you to get the current mapping in a collection and to modify it if necessary.
 
-<div class="alert alert-info">
-Once a field mapping has been set, it cannot be removed without reconstructing the collection.
-</div>
+:::info
+Once a field mapping has been set, it cannot be removed without recreating the collection.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/collection-mapping/set/index.md
+++ b/src/sdk/php/3/core-classes/collection-mapping/set/index.md
@@ -9,9 +9,9 @@ description: CollectionMapping:set
 
 Adds or updates a field mapping.
 
-<div class="alert alert-info">
-Changes made by this function won't be applied until you call the <code>apply</code> method
-</div>
+:::info
+Changes made by this function won't be applied until you call the `apply` method.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/collection/count/index.md
+++ b/src/sdk/php/3/core-classes/collection/count/index.md
@@ -9,9 +9,9 @@ description: Collection:count
 
 Returns the number of documents matching the provided set of filters.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned immediately by this function.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/collection/delete-document/index.md
+++ b/src/sdk/php/3/core-classes/collection/delete-document/index.md
@@ -9,9 +9,9 @@ description: Collection:deleteDocument
 
 Delete a stored document, or all stored documents matching a search filter.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is deleted and it being reflected in the search layer (usually a couple of seconds). That means that a document that was just deleted may still be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is deleted and it being reflected in the search layer (usually a couple of seconds). That means that a document that was just deleted might still be returned by this function.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/collection/scroll/index.md
+++ b/src/sdk/php/3/core-classes/collection/scroll/index.md
@@ -10,13 +10,13 @@ description: Collection:scroll
 Returns a [SearchResult](/sdk/php/3/core-classes/search-result/) object containing the next page of the scroll session, and the `scrollId` to be used in the next `scroll` action.
 A scroll session is always initiated by a `search` action and including the `scroll` argument; more information below.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned immediately by this function.
+:::
 
-<div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
-</div>
+:::info
+To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/collection/search/index.md
+++ b/src/sdk/php/3/core-classes/collection/search/index.md
@@ -9,9 +9,9 @@ description: Collection:search
 
 Executes a search on the collection.
 
-<div class="alert alert-info">
-There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned by this function at first.
-</div>
+:::info
+There is a small delay between the time a document is created and its availability in our search layer (usually a couple of seconds). That means that a document that was just created might not be returned immediately by this function.
+:::
 
 ## Processing large data sets
 
@@ -44,9 +44,9 @@ See [`SearchResult.fetchNext`](/sdk/php/3/core-classes/search-result/fetch-next/
 | `scroll`   | string  | Start a scroll session, with a time to live equals to this parameter's value following the [Elastisearch time format](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/common-options.html#time-units) | `undefined` |
 | `size`     | number  | Provide the maximum number of results of the request (used to paginate results)                                                                                                                                   | `10`        |
 
-<div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
-</div>
+:::info
+To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/document/set-content/index.md
+++ b/src/sdk/php/3/core-classes/document/set-content/index.md
@@ -10,9 +10,9 @@ description: Document:setContent
 Replaces the current content with new data.  
 This is a helper function returning a reference to itself so that you can easily chain calls.
 
-<div class="alert alert-info">
-Changes made by this function won't be applied until the <code>save</code> method is called
-</div>
+:::info
+Changes made by this function won't be applied until the `save` method is called
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/kuzzle/check-token/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/check-token/index.md
@@ -27,9 +27,9 @@ description: Kuzzle:checkToken
 
 Checks the validity of a JSON Web Token.
 
-<div class="alert alert-info">
+:::info
 This method is non-queuable, meaning that during offline mode, it will be discarded and the callback return an error.
-</div>
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/kuzzle/get-auto-refresh/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/get-auto-refresh/index.md
@@ -13,15 +13,11 @@ immediately after each write request, causing documents to be immediately visibl
 
 The `getAutoRefresh` function returns the current `autoRefresh` status for the given index.
 
-<div class="alert alert-warning">
-    <p>
-        A refresh operation comes with some performance costs.
-    </p>
-    <p>
-      While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid
-      using it in production or at least carefully monitor its implications before using it.
-    </p>
-</div>
+:::warning
+A refresh operation comes with some performance costs.
+
+While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid using it in production or at least carefully monitor its implications before using it.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/kuzzle/login/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/login/index.md
@@ -18,9 +18,9 @@ If the request succeeds but there is no token, then it means that the chosen str
 If the login attempt fails, the `loginAttempt` event is fired with the following response:
 `{ success: false, error: 'error message' }`
 
-<div class="alert alert-info">
-This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. [Learn more.](/core/1/guides/essentials/user-authentication/#local-strategy)
-</div>
+:::info
+This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/kuzzle/logout/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/logout/index.md
@@ -9,9 +9,9 @@ description: Kuzzle:logout
 
 Logs the user out.
 
-<div class="alert alert-info">
+:::info
 This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error.
-</div>
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/kuzzle/query/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/query/index.md
@@ -9,10 +9,10 @@ description: Kuzzle:query
 
 Base method used to send queries to Kuzzle, following the [API Documentation](/core/1/api).
 
-<div class="alert alert-warning">
-This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.<br/>
-Refer to Kuzzle's API Reference [here](/core/1/api)
-</div>
+:::warning
+This is a low-level method, exposed to allow advanced SDK users to bypass high-level methods.  
+Refer to Kuzzle's [API Reference](/core/1/api)
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/kuzzle/refresh-index/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/refresh-index/index.md
@@ -14,14 +14,13 @@ By default, this operation can take up to 1 second.
 Given an index, the `refresh` action forces a [`refresh`](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-refresh.html),
 on it, making the documents visible to search immediately.
 
-<div class="alert alert-warning">
-    A refresh operation comes with some performance costs.<br>
-    <br>
-    From <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-refresh.html">elasticsearch documentation</a>:
-    <div class="quote">
-    "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
-    </div>
-</div>
+:::warning
+A refresh operation comes with some performance costs.
+
+From the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-refresh.html):
+> "While a refresh is much lighter than a commit, it still has a performance cost. A manual refresh can be useful when writing tests, but don’t do a manual refresh every time you index a document in production; it will hurt your performance. Instead, your application needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/kuzzle/set-auto-refresh/index.md
+++ b/src/sdk/php/3/core-classes/kuzzle/set-auto-refresh/index.md
@@ -13,15 +13,12 @@ immediately after each write request, causing documents to be immediately visibl
 
 Given an index, the `setAutoRefresh` function updates its `autoRefresh` status.
 
-<div class="alert alert-warning">
-    <p>
-        A refresh operation comes with some performance costs.
-    </p>
-    <p>
-        While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid
-        using it in production or at least carefully monitor its implications before using it.
-    </p>
-</div>
+:::warning
+A refresh operation comes with some performance costs.
+
+While forcing the autoRefresh can be convenient on a development or test environmnent, we recommend that you avoid
+using it in production or at least carefully monitor its implications before using it.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/memory-storage/sort/index.md
+++ b/src/sdk/php/3/core-classes/memory-storage/sort/index.md
@@ -10,9 +10,9 @@ description: MemoryStorage:sort
 Sorts and returns elements contained in a list, a set of unique values or a sorted set.
 By default, sorting is numeric and elements are compared by their value interpreted as double precision floating point number.
 
-<div class="alert alert-info"
+:::info
 While Kuzzle's API supports the "store" option for this command, Kuzzle SDK methods do not. To sort and store in the same process, use the [query method](/sdk/php/3/core-classes/kuzzle/query/)
-</div>
+:::
 
 [[_Redis documentation_]](https://redis.io/commands/sort)
 

--- a/src/sdk/php/3/core-classes/profile/add-policy/index.md
+++ b/src/sdk/php/3/core-classes/profile/add-policy/index.md
@@ -9,9 +9,9 @@ description: Profile:addPolicy
 
 Adds a role to the security profile.
 
-<div class="alert alert-info">
+:::info
 Updating a security profile will have no impact until the [save](/sdk/php/3/core-classes/profile/save/) method is called
-</div>
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/profile/save/index.md
+++ b/src/sdk/php/3/core-classes/profile/save/index.md
@@ -9,9 +9,9 @@ description: Profile:save
 
 Creates or replaces the profile in Kuzzle.
 
-<div class="alert alert-warning">
+:::warning
 Saving the object will return an error if the linked roles have not been previously created in Kuzzle.
-</div>
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/profile/set-content/index.md
+++ b/src/sdk/php/3/core-classes/profile/set-content/index.md
@@ -9,9 +9,9 @@ description: Profile:setContent
 
 Replaces the content of the `Profile` object.
 
-<div class="alert alert-info">
-Updating a profile will have no impact until the <code>save</code> method is called
-</div>
+:::info
+Updating a profile will have no impact until the `save` method is called.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/profile/set-policies/index.md
+++ b/src/sdk/php/3/core-classes/profile/set-policies/index.md
@@ -31,6 +31,6 @@ Replaces the roles associated with this security profile.
 
 Returns the `Profile` object.
 
-<div class="alert alert-info">
-Updating a profile will have no impact until the <code>save</code> method is called
-</div>
+:::info
+Updating a profile will have no impact until the `save` method is called.
+:::

--- a/src/sdk/php/3/core-classes/role/set-content/index.md
+++ b/src/sdk/php/3/core-classes/role/set-content/index.md
@@ -9,9 +9,9 @@ description: Role:setContent
 
 Replaces the content of the `Role` object.
 
-<div class="alert alert-info">
+:::info
 Updating a role content will have no impact until the [save](/sdk/php/3/core-classes/role/save/) method is called
-</div>
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/role/update/index.md
+++ b/src/sdk/php/3/core-classes/role/update/index.md
@@ -9,15 +9,13 @@ description: Role:update
 
 Updates the role object in Kuzzle.
 
-<div class="alert alert-warning">
-  <p>
-    Unlike a regular document update, this method will replace the whole role definition under the indexes node with the <code>updateContent</code> parameter.<br>
-    In other words, you always need to provide the complete role definition in the <code>updateContent</code> object.
-  </p>
-  <p>
-    This method has the same effect as calling [`setContent`](/sdk/php/3/core-classes/role/set-content/) followed by the [`save`](/sdk/php/3/core-classes/role/save/) method.
-  </p>
-</div>
+:::warning
+Unlike a regular document update, this method will replace the whole role definition under the indexes node with the `updateContent` parameter.
+
+In other words, you always need to provide the complete role definition.
+
+This method has the same effect as calling [setContent](/sdk/php/3/core-classes/role/set-content/) followed by the [save](/sdk/php/3/core-classes/role/save/) method.
+:::
 
 To get more information about Kuzzle permissions, please refer to our [permissions guide](/core/1/guides/essentials/security/#user-permissions).
 

--- a/src/sdk/php/3/core-classes/search-result/fetch-next/index.md
+++ b/src/sdk/php/3/core-classes/search-result/fetch-next/index.md
@@ -25,9 +25,13 @@ If the previous request was a search action which provided `from` and `size` arg
 
 The safest way to process all documents in a collection is to fetch them as a batch in order to avoid memory exhaustion and possibly hitting some hard limits<sup>\[1\]</sup> on the database layer.
 
-<div class="alert alert-warning">Make sure your first search request includes <code>size</code> and <code>scroll</code> parameters</div>
+:::warning
+Make sure your first search request includes both a `size` and a `scroll` parameters
+:::
 
-<div class="alert alert-info"><sup>\[1\]</sup> Elasticsearch limits the number of documents inside a single page to [10,000 by default](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/index-modules.html#dynamic-index-settings).</div>
+:::info
+<sup>\[1\]</sup> Elasticsearch limits the number of documents inside a single page to [10,000 by default](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/index-modules.html#dynamic-index-settings).
+:::
 
 ## Usage
 

--- a/src/sdk/php/3/core-classes/security/create-profile/index.md
+++ b/src/sdk/php/3/core-classes/security/create-profile/index.md
@@ -9,10 +9,10 @@ description: Security:createProfile
 
 Create a new profile in Kuzzle.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between profile creation and its availability in our search layer (usually a couple of seconds).
-That means that a profile that was just created might not be returned by the <code>searchProfiles</code> function at first.
-</div>
+That means that a profile that was just created might not be returned immediately by the [searchProfiles](/sdk/php/3/core-classes/security/search-profiles/) function.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/security/create-restricted-user/index.md
+++ b/src/sdk/php/3/core-classes/security/create-restricted-user/index.md
@@ -10,10 +10,10 @@ description: Security:createRestrictedUser
 Create a new restricted user in Kuzzle.
 This function allows anonymous users to create a "restricted" user with predefined rights.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between user creation and its availability in our search layer (usually a couple of seconds).
-That means that a user that was just created may not be returned by the <code>searchUsers</code> function at first.
-</div>
+That means that a user that was just created may not be returned immediately by the [searchUsers](/sdk/php/3/core-classes/security/search-users/) function.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/security/create-role/index.md
+++ b/src/sdk/php/3/core-classes/security/create-role/index.md
@@ -9,10 +9,11 @@ description: Security:createRole
 
 Create a new role in Kuzzle.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between role creation and its availability in our search layer (usually a couple of seconds).
-That means that a role that was just created may not be returned by the <code>searchRole</code> function at first.
-</div>
+That means that a role that was just created may not be returned immediately by the [searchRoles](/sdk/php/3/core-classes/security/search-roles/) function.
+:::
+
 ---
 
 ## createRole(id, content, [options], callback)

--- a/src/sdk/php/3/core-classes/security/create-user/index.md
+++ b/src/sdk/php/3/core-classes/security/create-user/index.md
@@ -9,10 +9,10 @@ description: Security:createUser
 
 Create a new user in Kuzzle.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between user creation and its availability in our search layer (usually a couple of seconds).
-That means that a user that was just created may not be returned by the <code>searchUsers</code> function at first.
-</div>
+That means that a user that was just created may not be returned by the [searchUsers](/sdk/php/3/core-classes/security/search-users/) function at first.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/security/delete-profile/index.md
+++ b/src/sdk/php/3/core-classes/security/delete-profile/index.md
@@ -9,10 +9,10 @@ description: Security:deleteProfile
 
 Delete the provided profile.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between the time a profile is deleted and it being reflected in the search layer (usually a couple of seconds).
-That means that a profile that was just deleted may still be returned by the <code>searchProfiles</code> function at first.
-</div>
+That means that a profile that was just deleted might still be returned by the [searchProfiles](/sdk/php/3/core-classes/security/search-profiles/) function.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/security/delete-role/index.md
+++ b/src/sdk/php/3/core-classes/security/delete-role/index.md
@@ -9,10 +9,10 @@ description: Security:deleteRole
 
 Delete the provided role.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between the time a role is deleted and it being reflected in the search layer (usually a couple of seconds).
-That means that a role that was just deleted may still be returned by the <code>searchRoles</code> function at first.
-</div>
+That means that a role that was just deleted might still be returned by the [searchRoles](/sdk/php/3/core-classes/security/search-roles/) function.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/security/delete-user/index.md
+++ b/src/sdk/php/3/core-classes/security/delete-user/index.md
@@ -9,10 +9,10 @@ description: Security:deleteUser
 
 Delete the provided user.
 
-<div class="alert alert-info">
+:::info
 There is a small delay between the time a user is deleted and it being reflected in the search layer (usually a couple of seconds).
-That means that a user that has just been deleted may still be returned by the <code>searchUsers</code> function at first.
-</div>
+That means that a user that has just been deleted might still be returned by the [searchUsers](/sdk/php/3/core-classes/security/search-users/) function.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/security/is-action-allowed/index.md
+++ b/src/sdk/php/3/core-classes/security/is-action-allowed/index.md
@@ -15,9 +15,9 @@ Specifies if an action is allowed, denied or conditional based on the rights pro
 
 An action is defined as a pair of action and controller (mandatory), plus an index and a collection(optional).
 
-<div class="alert alert-info">
-You can get the rights from Kuzzle by using [`Security.getUserRights`](/sdk/php/3/core-classes/security/get-user-rights/) and [`Kuzzle.getMyRights`](/sdk/php/3/core-classes/kuzzle/get-my-rights/).
-</div>
+:::info
+You can get the rights from Kuzzle by using [Security.getUserRights](/sdk/php/3/core-classes/security/get-user-rights/) and [Kuzzle.getMyRights](/sdk/php/3/core-classes/kuzzle/get-my-rights/).
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/security/search-users/index.md
+++ b/src/sdk/php/3/core-classes/security/search-users/index.md
@@ -30,9 +30,9 @@ Return users matching the given filter.
 | `scroll`   | string  | Start a scroll session, with a time to live equals to this parameter's value following the [Elastisearch time format](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/common-options.html#time-units) | `undefined` |
 | `size`     | number  |  Number of hits to return per result page                                                                                                                                                                         | `10`        |
 
-<div class="alert alert-info">
-  To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
-</div>
+:::info
+To get more information about scroll sessions, please refer to the [API reference documentation](/core/1/api/controllers/document/search/).
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/user/add-profile/index.md
+++ b/src/sdk/php/3/core-classes/user/add-profile/index.md
@@ -9,9 +9,9 @@ description: User:addProfile
 
 Replaces the security profile associated with the user.
 
-<div class="alert alert-info">
-Updating a user will have no impact until the [`create`](/sdk/php/3/core-classes/user/create/) or [`replace`](/sdk/php/3/core-classes/user/replace/) method is called
-</div>
+:::info
+Updating a user will have no impact until the [create](/sdk/php/3/core-classes/user/create/) or [replace](/sdk/php/3/core-classes/user/replace/) method is called
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/user/set-content/index.md
+++ b/src/sdk/php/3/core-classes/user/set-content/index.md
@@ -9,9 +9,9 @@ description: User:setContent
 
 Replaces the content of User.
 
-<div class="alert alert-info">
-Updating a user will have no impact until the [`create`](/sdk/php/3/core-classes/user/create/) or [`replace`](/sdk/php/3/core-classes/user/replace/) method is called
-</div>
+:::info
+Updating a user will have no impact until the [create](/sdk/php/3/core-classes/user/create/) or [replace](/sdk/php/3/core-classes/user/replace/) method is called.
+:::
 
 ---
 

--- a/src/sdk/php/3/core-classes/user/set-credentials/index.md
+++ b/src/sdk/php/3/core-classes/user/set-credentials/index.md
@@ -9,10 +9,11 @@ description: User:setCredentials
 
 Sets the user's credentials.
 
-<div class="alert alert-info">
-  Updating user credentials will have no impact until the [`create`](/sdk/php/3/core-classes/user/create/) method is called.<br />
-  The credentials to send depend on the authentication plugin and the strategy you want to create credentials for.
-</div>
+:::info
+Updating user credentials will have no impact until the [create](/sdk/php/3/core-classes/user/create/) method is called.  
+The credentials to send depend on the authentication plugin and the strategy you want to create credentials for.
+:::
+
 ---
 
 ## setCredentials(credentials)

--- a/src/sdk/php/3/core-classes/user/set-profiles/index.md
+++ b/src/sdk/php/3/core-classes/user/set-profiles/index.md
@@ -9,9 +9,10 @@ description: User:setProfiles
 
 Replaces the security profiles linked to the user.
 
-<div class="alert alert-info">
-Updating a user will have no impact until the <code>create</code> or <code>replace</code> method is called
-</div>
+:::info
+Updating a user will have no impact until either the [create](/sdk/php/3/core-classes/user/create/) or [replace](/sdk/php/3/core-classes/user/replace/) method is called.
+:::
+
 ---
 
 ## setProfiles(profileIds)


### PR DESCRIPTION
# Description

As the title says, this PR replaces the old `<div class="alert alert-<alert type>">` tags with the new `:::<alert type>` one, fixing many broken URL decorations.

Example of broken URLs in an old alert paragraph: https://docs.kuzzle.io/core/1/plugins/guides/pipes/

All documentation sections have been fixed except for the JS SDK 5 one: I'll fix that one in a branch depending of that PR: https://github.com/kuzzleio/sdk-javascript/pull/401

# Other change

* links checker: properly output external dead links in the logs
* links checker: now removes anything following the paren closing the URL as it's not part of the link to check

# Boyscout

* Fix direct uses of `<a href=...>` whenever possible (there is 1 location when using markdown is broken, and there is the problem of URLs between `<pre>` tags)
* Fix a few wordings here and there