### PR TITLE
[fix] Social links in the footer

### DIFF
--- a/src/.vuepress/theme/Layout.vue
+++ b/src/.vuepress/theme/Layout.vue
@@ -9,7 +9,7 @@
           <!-- Main navigation -->
           <Sidebar ref="sidebar" v-if="!$page.frontmatter.nosidebar" :sidebar-open="sidebarOpen"/>
           <!-- Table of contents -->
-          <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+          <div ref="toc" class="md-sidebar md-sidebar--secondary" data-md-component="toc">
             <div class="md-sidebar__scrollwrap">
               <div class="md-sidebar__inner">
                 <div v-if="$route.path.match(/^\/sdk\//)" class="selector-container">
@@ -140,6 +140,7 @@ export default {
       }
 
       this.$refs.sidebar.$el.style = `height: ${sidebarHeight}px`;
+      this.$refs.toc.style = `height: ${sidebarHeight}px`;
     }
   },
   mounted() {


### PR DESCRIPTION
## What does this PR do?
The height of the TOC (on the right side of the page) was set to 100% by default, but this overlapped with the social links on the footer. The height of the TOC is now set to the same value of the height of the Sidebar. The social links are now clickable.

### How should this be manually tested?
Scroll to the bottom and click on the social links.