### PR TITLE
[feature] Identifiable partial snippets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
       "type": "node",
       "request": "launch",
       "name": "Debug VuePress",
+      "console": "integratedTerminal",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run-script", "debug"],
       // "localRoot": "${workspaceFolder}/src/.vuepress/",

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -234,7 +234,7 @@ module.exports = {
       permalinkSymbol: ''
     },
     extendMarkdown: md => {
-      md.use(require('./markdown/relative-snippet'));
+      md.use(require('./markdown/code-snippet'));
       md.use(require('./markdown/copy-paste-snippet-btn'));
     }
   },

--- a/src/sdk/java/1/controllers/realtime/subscribe/index.md
+++ b/src/sdk/java/1/controllers/realtime/subscribe/index.md
@@ -29,18 +29,13 @@ public String subscribe(
 
 <br/>
 
-| Arguments    | Type                                                                                                       | Description                                                                                        |
-| ------------ | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `index`      | <pre>String</pre>                                                                                          | Index name                                                                                         |
-| `collection` | <pre>String</pre>                                                                                          | Collection name                                                                                    |
-<<<<<<< HEAD
-| `filters`    | <pre>String</pre>                                                                                          | JSON string representing a set of filters following [Koncorde syntax](/core/1/guides/cookbooks/realtime-api/) |
-| `listener`   | <pre>[io.kuzzle.sdk.NotificationListener](/sdk/java/1/essentials/realtime-notifications/)</pre> | Listener function to handle notifications                                                          |
-=======
-| `filters`    | <pre>String</pre>                                                                                          | JSON string representing a set of filters following [Koncorde syntax](/core/1/guides/cookbooks/realtime-api/) |
-| `listener`   | <pre><a href="/sdk/java/1/essentials/realtime-notifications/">io.kuzzle.sdk.NotificationListener</a></pre> | Listener function to handle notifications                                                          |
->>>>>>> origin/add-s3-plugin-doc
-| `options`    | <pre>io.kuzzle.sdk.RoomOptions</pre>                                                                       | Subscription options                                                                               |
+| Arguments    | Type                                                                                            | Description                                                                                                   |
+| ------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `index`      | <pre>String</pre>                                                                               | Index name                                                                                                    |
+| `collection` | <pre>String</pre>                                                                               | Collection name                                                                                               |
+| `filters`    | <pre>String</pre>                                                                               | JSON string representing a set of filters following [Koncorde syntax](/core/1/guides/cookbooks/realtime-api/) |
+| `listener`   | <pre>[io.kuzzle.sdk.NotificationListener](/sdk/java/1/essentials/realtime-notifications/)</pre> | Listener function to handle notifications                                                                     |
+| `options`    | <pre>io.kuzzle.sdk.RoomOptions</pre>                                                            | Subscription options                                                                                          |
 
 ### options
 

--- a/src/sdk/js/6/getting-started/webpack/index.md
+++ b/src/sdk/js/6/getting-started/webpack/index.md
@@ -154,7 +154,7 @@ confirm that your document was saved.
 :::
 
 ::: info
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
+Having trouble? Get in touch with us on [Gitter!](https://gitter.im/kuzzleio/kuzzle) We're happy to help.
 :::
 
 ## Subscribe to realtime document notifications (pub/sub)

--- a/src/sdk/js/6/getting-started/webpack/index.md
+++ b/src/sdk/js/6/getting-started/webpack/index.md
@@ -19,15 +19,15 @@ Before going through this tutorial, you should have a Kuzzle server running. Ple
 
 It's time to play with the [Kuzzle Javscript SDK](/sdk/js/6). In this section, we will store a document and subscribe to notifications in Kuzzle using the Javascript SDK in your browser.
 
-Before proceeding, please make sure your system has **Node.js** version 8 or higher (<a href="https://nodejs.org/en/download/">instructions here</a>) installed.
+Before proceeding, please make sure your system has **Node.js** version 8 or higher ([instructions here](https://nodejs.org/en/download/)) installed.
 
 ## Including the Kuzzle SDK in a Webpack project
 
-<div class="alert alert-info">
-    This section explains how to use the Kuzzle SDK within an existing Webpack project.
-    If you don't have your project up and running yet and want to learn how to leverage Webpack to build it, please refer to
-    the <a href="https://webpack.js.org/guides/getting-started/">official Webpack Getting Started page</a>.
-</div>
+::: info
+This section explains how to use the Kuzzle SDK within an existing Webpack project.
+If you don't have your project up and running yet and want to learn how to leverage Webpack to build it, please refer to
+the [official Webpack Getting Started page](https://webpack.js.org/guides/getting-started/).
+:::
 
 In your terminal, go to the root of your front-end project using Webpack and type
 
@@ -35,29 +35,21 @@ In your terminal, go to the root of your front-end project using Webpack and typ
 npm install kuzzle-sdk
 ```
 
-<div class="alert alert-info">
-If you are performing a clean install you might see some <code>unmet peer dependency</code> warnings, these are safe to ignore as they refer to optional dependencies.
-</div>
+::: info
+If you are performing a clean install you might see some `unmet peer dependency` warnings, these are safe to ignore as they refer to optional dependencies.
+:::
 
 Then, create a `init-kuzzle.js` file and start by adding the code below. This will load the Kuzzle Javascript SDK:
 
-```js
-import { Kuzzle, WebSocket } from 'kuzzle-sdk';
-```
+<<< ./snippets/init-kuzzle.js:1
 
 Next, we instantiate a client that will connect to Kuzzle via WebSocket. If Kuzzle is not running on localhost, replace it with the corresponding server name or IP address.
 
-```js
-const kuzzle = new Kuzzle(new WebSocket('localhost'));
-```
+<<< ./snippets/init-kuzzle.js:2
 
 Next we add a listener to be notified in case of a connection error:
 
-```js
-kuzzle.on('networkError', error => {
-  console.error(`Network Error: ${error}`);
-});
-```
+<<< ./snippets/init-kuzzle.js:3
 
 Then we have to connect our web app to the Kuzzle server with the `connect()` method.
 
@@ -66,7 +58,6 @@ const run = async () => {
   try {
     // Connect to Kuzzle server
     await kuzzle.connect();
-
     // Some more things will go here...
   } catch (error) {
     console.error(error.message);
@@ -79,24 +70,7 @@ const run = async () => {
 Finally, we will create a new index `nyc-open-data` and a new collection
 `yellow-taxi` that we will use to store data later on.
 
-```js
-const run = async () => {
-  try {
-    // Connect to Kuzzle server
-    await kuzzle.connect();
-
-    // Create an index
-    await kuzzle.index.create('nyc-open-data');
-    // Create a collection
-    await kuzzle.collection.create('nyc-open-data', 'yellow-taxi');
-    console.log('nyc-open-data/yellow-taxi ready!');
-  } catch (error) {
-    console.error(error.message);
-  } finally {
-    kuzzle.disconnect();
-  }
-};
-```
+<<< ./snippets/init-kuzzle.js:4
 
 Your `kuzzle-init.js` file should now look like this:
 
@@ -124,13 +98,13 @@ Your console should output the following message:
 nyc-open-data/yellow-taxi ready!
 ```
 
-<div class="alert alert-success">
+::: success
 Congratulations! You are now ready to say Hello to the World!
-</div>
+:::
 
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+::: info
+Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)! We're happy to help.
+:::
 
 ## Create your first document
 
@@ -172,16 +146,16 @@ Now, click the button and check your console for a message like the following:
 New document successfully created!
 ```
 
-<div class="alert alert-success">
-    You have now successfully stored your first document into Kuzzle. Click
-    [here](/core/1/guides/essentials/admin-console/) to see how you can use the
-    <strong><a href="http://console.kuzzle.io/">Kuzzle Admin Console</a></strong> to browse your collection and
-    confirm that your document was saved.
-</div>
+::: success
+You have now successfully stored your first document into Kuzzle. Click
+[here](/core/1/guides/essentials/admin-console/) to see how you can use the
+[**Kuzzle Admin Console**](http://console.kuzzle.io/) to browse your collection and
+confirm that your document was saved.
+:::
 
-<div class="alert alert-info">
+::: info
 Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+:::
 
 ## Subscribe to realtime document notifications (pub/sub)
 
@@ -216,13 +190,13 @@ New driver Sirkis with id <driver-id> has B license.
 
 In place of `<driver-id>` you'll see the ID that Kuzzle automatically generated for the document.
 
-<div class="alert alert-success">
+::: success
 Congratulations! You have just choreographed your first pub/sub pattern!
-</div>
+:::
 
-<div class="alert alert-info">
-Having trouble? Get in touch with us on <a href="https://gitter.im/kuzzleio/kuzzle">Gitter!</a> We're happy to help.
-</div>
+::: info
+Having trouble? Get in touch with us on [Gitter!](https://gitter.im/kuzzleio/kuzzle) We're happy to help.
+:::
 
 ## Where do we go from here?
 

--- a/src/sdk/js/6/getting-started/webpack/index.md
+++ b/src/sdk/js/6/getting-started/webpack/index.md
@@ -103,7 +103,7 @@ Congratulations! You are now ready to say Hello to the World!
 :::
 
 ::: info
-Having trouble? Get in touch with us on [Gitter](https://gitter.im/kuzzleio/kuzzle)! We're happy to help.
+Having trouble? Get in touch with us on [Gitter!](https://gitter.im/kuzzleio/kuzzle) We're happy to help.
 :::
 
 ## Create your first document

--- a/src/sdk/js/6/getting-started/webpack/snippets/init-kuzzle.js
+++ b/src/sdk/js/6/getting-started/webpack/snippets/init-kuzzle.js
@@ -1,14 +1,21 @@
 // load the Kuzzle SDK module
+/* snippet:start:1 */
 import { Kuzzle, WebSocket } from 'kuzzle-sdk';
+/* snippet:end */
 
 // instantiate a Kuzzle client
+/* snippet:start:2 */
 const kuzzle = new Kuzzle(new WebSocket('kuzzle'));
+/* snippet:end */
 
 // add a listener to detect any connection problems
+/* snippet:start:3 */
 kuzzle.on('networkError', error => {
   console.error(`Network Error: ${error}`);
 });
+/* snippet:end */
 
+/* snippet:start:4 */
 const run = async () => {
   try {
     // Connect to Kuzzle server
@@ -26,5 +33,6 @@ const run = async () => {
     kuzzle.disconnect();
   }
 };
+/* snippet:end */
 
 run();


### PR DESCRIPTION
## What does this PR do?
Introduces the ability of importing parts of an external snippet file with the syntax in the Markdown

```
<<< ./snippets/my-snippet.js:4
```

Where the snippet file contains partial snippet tags in the comments, like

```javascript
// load the Kuzzle SDK module
/* snippet:start:1 */
import { Kuzzle, WebSocket } from 'kuzzle-sdk';
/* snippet:end */

// instantiate a Kuzzle client
/* snippet:start:2 */
const kuzzle = new Kuzzle(new WebSocket('kuzzle'));
/* snippet:end */

// add a listener to detect any connection problems
/* snippet:start:3 */
kuzzle.on('networkError', error => {
  console.error(`Network Error: ${error}`);
});
/* snippet:end */

/* snippet:start:4 */
const run = async () => {
  try {
    // Connect to Kuzzle server
    await kuzzle.connect();

    // Create an index
    await kuzzle.index.create('nyc-open-data');

    // Create a collection
    await kuzzle.collection.create('nyc-open-data', 'yellow-taxi');
    console.log('nyc-open-data/yellow-taxi ready!');
  } catch (error) {
    console.error(error.message);
  } finally {
    kuzzle.disconnect();
  }
};
/* snippet:end */

run();
```

### How should this be manually tested?
Take  a look at the code of the "Getting Started with Webpack" tutorial in the Javascript SDK. Small parts of the `init-kuzzle.js` are imported before the whole file is imported itself.

### Other changes

* The `relative-snippet.js` has been renamed to `code-snippet.js`
* The "Getting Started with Webpack" tutorial in the Javascript SDK now uses this feature.

### Boyscout

* Fixed merge comment left in `src/sdk/java/1/controllers/realtime/subscribe/index.md`
* Migrated the `alert` blocks and HTML links in the "Getting Started with Webpack" tutorial.