### PR TITLE
[evol] 's' for Search

### DIFF
--- a/src/.vuepress/theme/Search.vue
+++ b/src/.vuepress/theme/Search.vue
@@ -8,7 +8,7 @@
           type="text"
           class="md-search__input"
           name="query"
-          placeholder="Search (ctrl+alt+S)"
+          placeholder="Search (s)"
           autocapitalize="off"
           autocorrect="off"
           autocomplete="off"
@@ -132,11 +132,7 @@ export default {
     initializeHotkey() {
       // TODO MacOS version
       window.addEventListener('keyup', event => {
-        if (
-          event.altKey === true &&
-          event.ctrlKey === true &&
-          event.key === 's'
-        ) {
+        if (event.key === 's') {
           this.$refs.searchInput.focus();
         }
       });


### PR DESCRIPTION
## What does this PR do?
Restore the 's' shortcut to focus the Algolia search bar (simpler and cross-platform)

### How should this be manually tested?
Open the documentation. Press 's'.
