### PR TITLE
[API] Fix the missing optional "refresh" argument for user creation routes

### DIFF
--- a/src/core/1/api/controllers/security/create-restricted-user/index.md
+++ b/src/core/1/api/controllers/security/create-restricted-user/index.md
@@ -6,8 +6,6 @@ title: createRestrictedUser
 
 # createRestrictedUser
 
-
-
 Creates a new user in Kuzzle, with a preset list of security profiles.
 
 The list of security profiles attributed to restricted users is fixed, and must be configured in the [Kuzzle configuration file](/core/1/guides/essentials/configuration/).
@@ -49,7 +47,6 @@ Body:
 {
   "controller": "security",
   "action": "createRestrictedUser",
-  "_id": "<kuid>",
   "body": {
     "content": {
       "fullname": "John Doe"
@@ -61,7 +58,11 @@ Body:
         password: "foobar"
       }
     }
-  }
+  },
+
+  // optional arguments
+  "_id": "<kuid>",
+  "refresh": "wait_for"
 }
 ```
 
@@ -72,6 +73,7 @@ Body:
 ### Optional:
 
 - `_id`: user [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier). An error is returned if the provided identifier already exists. If not provided, a random kuid is automatically generated.
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created user is indexed
 
 ---
 

--- a/src/core/1/api/controllers/security/create-user/index.md
+++ b/src/core/1/api/controllers/security/create-user/index.md
@@ -6,8 +6,6 @@ title: createUser
 
 # createUser
 
-
-
 Creates a new user.
 
 The body contains the user data and must have the following properties:
@@ -48,7 +46,6 @@ Body:
 {
   "controller": "security",
   "action": "createUser",
-  "_id": "<kuid>",
   "body": {
     "content": {
       "profileIds": ["<profileId>"],
@@ -62,7 +59,11 @@ Body:
         password: "foobar"
       }
     }
-  }
+  },
+
+  // optional arguments
+  "_id": "<kuid>",
+  "refresh": "wait_for"
 }
 ```
 
@@ -73,6 +74,7 @@ Body:
 ### Optional:
 
 - `_id`: user [kuid](/core/1/guides/kuzzle-depth/authentication/#the-kuzzle-user-identifier). An error is returned if the provided identifier already exists. If not provided, a random kuid is automatically generated.
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created user is indexed
 
 ---
 


### PR DESCRIPTION
# Description

The optional `refresh` option is undocumented for the following API route pages: [security:createUser](https://docs.kuzzle.io/core/1/api/controllers/security/create-user) and [security:createRestrictedUser](https://docs.kuzzle.io/core/1/api/controllers/security/create-restricted-user/)
