### PR TITLE
363 Fix wrong scope for accessors execute

### DIFF
--- a/src/core/1/plugins/plugin-context/accessors/execute/index.md
+++ b/src/core/1/plugins/plugin-context/accessors/execute/index.md
@@ -41,12 +41,12 @@ How the response is returned depends whether a callback argument is provided:
 ## Example
 
 ```js
-const request = new context.constructors.Request({
-  index: 'index',
-  collection: 'collection',
+let request = new context.constructors.Request({
   controller: 'document',
   action: 'get',
-  _id: 'documentID'
+  index: 'nyc-open-data',
+  collection: 'yellow-taxi',
+  _id: 'AWaCRnfbiSV6vMG7iV_K'
 });
 
 try {


### PR DESCRIPTION
## What does this PR do?

Use `let` instead of `const ` because we are reassigning the variable

Fix https://github.com/kuzzleio/documentation/issues/363