### PR TITLE
[plugins] Fix invalid example: cannot assign to a const variable

### DIFF
--- a/src/core/1/plugins/plugin-context/accessors/execute/index.md
+++ b/src/core/1/plugins/plugin-context/accessors/execute/index.md
@@ -6,8 +6,6 @@ title: execute
 
 # execute
 
-
-
 Executes a Kuzzle's [API action](/core/1/api/).
 
 ---
@@ -50,10 +48,10 @@ const request = new context.constructors.Request({
 });
 
 try {
-  // "request" is the updated Request object
-  // The API response is accessed through "request.response"
-  request = await context.accessors.execute(request);
+  // Mutates the provided Request object by updating the response part of
+  // it (accessible through the "request.response" property).
+  await context.accessors.execute(request);
 } catch (error) {
-  // "error" is a KuzzleError object
+  // "error" is an object inheriting the KuzzleError class
 }
 ```


### PR DESCRIPTION
# Description

Fix a code example where a constant variable is being assigned to.

fix #363 