### PR TITLE
[feature] Highlight lines in code-snippets

### DIFF
--- a/src/.vuepress/markdown/copy-paste-snippet-btn.js
+++ b/src/.vuepress/markdown/copy-paste-snippet-btn.js
@@ -3,11 +3,13 @@ module.exports = md => {
   md.renderer.rules.fence = (...args) => {
     const [tokens, idx] = args;
     const rawCode = fence(...args);
-    const codeWithButton = rawCode.replace(
-      '<!--afterbegin-->',
-      `${renderButton(idx)}<!--afterbegin-->`
-    );
-    return codeWithButton;
+    return rawCode
+      .replace(
+        '<!--beforebegin-->',
+        '<!--beforebegin--><div class="code-block">'
+      )
+      .replace('<!--afterend-->', '</div><!--afterend-->')
+      .replace('<!--afterbegin-->', `${renderButton(idx)}<!--afterbegin-->`);
   };
 };
 

--- a/src/.vuepress/theme/styles/_config.scss
+++ b/src/.vuepress/theme/styles/_config.scss
@@ -66,8 +66,8 @@ $md-icon-padding: $ms-base * 0.5;
 $md-icon-margin: $ms-base * 0.25;
 
 // Code blocks
-$md-code-background: #083b4b;
-$md-code-background-highlighted: #002835;
+$md-code-background: $md-color-blue;
+$md-code-background-highlighted: #02171f;
 $md-code-color: #c2c6cf;
 
 // Keystrokes

--- a/src/.vuepress/theme/styles/_config.scss
+++ b/src/.vuepress/theme/styles/_config.scss
@@ -66,7 +66,8 @@ $md-icon-padding: $ms-base * 0.5;
 $md-icon-margin: $ms-base * 0.25;
 
 // Code blocks
-$md-code-background: #002835;
+$md-code-background: #083b4b;
+$md-code-background-highlighted: #002835;
 $md-code-color: #c2c6cf;
 
 // Keystrokes

--- a/src/.vuepress/theme/styles/base/_typeset.scss
+++ b/src/.vuepress/theme/styles/base/_typeset.scss
@@ -188,7 +188,6 @@ kbd {
     $correct: 1 / 0.85;
     padding: 3px;
     border-radius: 0.2rem;
-    background-color: $md-code-background-inline;
     color: black;
     font-weight: normal;
     // Remove box-shadows for print

--- a/src/.vuepress/theme/styles/base/_typeset.scss
+++ b/src/.vuepress/theme/styles/base/_typeset.scss
@@ -56,7 +56,7 @@ kbd {
     font-weight: 300;
     letter-spacing: -0.01em;
     line-height: 1.3;
-    
+
     code {
       font-size: ms(3);
     }
@@ -147,9 +147,33 @@ kbd {
   }
 
   // Code blocks
-  pre > code{
-    font-family: 'Roboto Mono', 'Courier New', Courier, monospace;
+  .code-block {
     background-color: $md-code-background;
+    border-radius: 0.2rem;
+
+    div[class*='language-'] {
+      position: relative;
+
+      .highlight-lines {
+        position: absolute;
+        padding: 1.05rem 0rem;
+      }
+    }
+  }
+
+  .highlight-lines {
+    width: 100%;
+    font-family: 'Roboto Mono', 'Courier New', Courier, monospace;
+    font-size: 1.4rem;
+    line-height: 23px;
+
+    .highlighted {
+      background-color: $md-code-background-highlighted;
+    }
+  }
+
+  pre > code {
+    font-family: 'Roboto Mono', 'Courier New', Courier, monospace;
     font-size: 1.4rem;
     direction: ltr;
     color: white;
@@ -158,7 +182,7 @@ kbd {
       white-space: pre-wrap;
     }
   }
-  
+
   // Inline code blocks, correct relative ems for smaller font size
   code {
     $correct: 1 / 0.85;
@@ -197,7 +221,6 @@ kbd {
       margin: 0;
       padding: 1.05rem 1.2rem;
       padding-bottom: 5px;
-      background-color: $md-code-background;
       font-size: inherit;
       box-shadow: none;
       box-decoration-break: none;

--- a/src/.vuepress/theme/styles/libs/_prism.scss
+++ b/src/.vuepress/theme/styles/libs/_prism.scss
@@ -37,7 +37,6 @@ pre[class*='language-'] {
 
 :not(pre) > code[class*='language-'],
 pre[class*='language-'] {
-  background: #2d2d2d;
 }
 
 /* Inline code */

--- a/src/core/1/guides/getting-started/first-steps/index.md
+++ b/src/core/1/guides/getting-started/first-steps/index.md
@@ -40,7 +40,7 @@ Next, instantiate a client that automatically connects to Kuzzle via WebSocket. 
 
 Finally, we will add the code that will access Kuzzle to create a new index 'playground' and a new collection 'mycollection' that we will use to store data later on.
 
-<<< ./snippets/init-sample.js
+<<< ./snippets/init-sample.js{3,5,6,7,8}
 
 Your `first-step.js` file should now look like this:
 


### PR DESCRIPTION
## What does this PR do?
Introduces the ability to highlight certain code lines in a snippet with the syntax

```
<<< ./snippets/init-sample.js{3,5,6,7,8}
```

![Selection_054](https://user-images.githubusercontent.com/5023426/60084563-0dfa9700-9738-11e9-8f8f-ab554b71501c.png)


### How should this be manually tested?
Take a look at the init snippet in the First Steps with Kuzzle guide or apply the same syntax to another snippet.