### PR TITLE
Fix broken links to koncorde terms & operands

### DIFF
--- a/src/core/1/guides/cookbooks/realtime-api/introduction/index.md
+++ b/src/core/1/guides/cookbooks/realtime-api/introduction/index.md
@@ -122,4 +122,4 @@ node koncorde-demo.js
 
 Feel free to play with the `geoDistance` position and radius,
 as well as with tested points to see the different results in the previous example.
-You can also dive into more complex filters by playing with other [terms](/core/1/guides/cookbooks/realtime-api//terms) and [operands](/core/1/guides/cookbooks/realtime-api//operands).
+You can also dive into more complex filters by playing with other [terms](/core/1/guides/cookbooks/realtime-api/terms) and [operands](/core/1/guides/cookbooks/realtime-api/operands).

--- a/src/core/1/guides/essentials/real-time/index.md
+++ b/src/core/1/guides/essentials/real-time/index.md
@@ -242,7 +242,7 @@ These filters are specified only on the client side and do not require server-si
 They are sent in the body of the request [realtime:subscribe](/core/1/api/controllers/realtime/subscribe)
 :::
 
-A filter is composed of [term](/core/1/guides/cookbooks/realtime-api//terms) that can be composed with [operands](/core/1/guides/cookbooks/realtime-api//operands).
+A filter is composed of [term](/core/1/guides/cookbooks/realtime-api/terms) that can be composed with [operands](/core/1/guides/cookbooks/realtime-api/operands).
 
 For example if I want to receive only drivers with the `B` license:
 ```json
@@ -257,7 +257,7 @@ For example if I want to receive only drivers with the `B` license:
 }
 ```
 
-It is also possible to combine [terms](/core/1/guides/cookbooks/realtime-api//terms) between them with [operands](/core/1/guides/cookbooks/realtime-api//operands) to refine my filter:
+It is also possible to combine [terms](/core/1/guides/cookbooks/realtime-api/terms) between them with [operands](/core/1/guides/cookbooks/realtime-api/operands) to refine my filter:
 
 ```json
 {

--- a/src/sdk/cpp/1/controllers/realtime/subscribe/index.md
+++ b/src/sdk/cpp/1/controllers/realtime/subscribe/index.md
@@ -32,7 +32,7 @@ std::string subscribe(
 | ------------ | ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `index`      | <pre>const std::string&</pre>               | Index name                                                                                                |
 | `collection` | <pre>const std::string&</pre>               | Collection name                                                                                           |
-| `filters`    | <pre>const std::string&</pre>               | JSON string representing a set of filters following [Koncorde syntax](/core/1/guides/cookbooks/realtime-api//terms/) |
+| `filters`    | <pre>const std::string&</pre>               | JSON string representing a set of filters following [Koncorde syntax](/core/1/guides/cookbooks/realtime-api/terms/) |
 | `listener`   | <pre>kuzzleio::NotificationListener\*</pre> | Listener function to handle notifications                                                                 |
 | `options`    | <pre>kuzzleio::room_options\*</pre>         | Subscription options                                                                                      |
 


### PR DESCRIPTION
## What does this PR do?
<!-- Please fulfill this section -->
Fix several broken links : they were redirecting to `core/1/guides/cookbooks/realtime-api//terms/` (& operands) instead of `core/1/guides/cookbooks/realtime-api/terms/` (& operands)