### PR TITLE
KZL-1281-add-sdk-selector-in-sidebar

### DIFF
--- a/src/.vuepress/components/SDKSelector.vue
+++ b/src/.vuepress/components/SDKSelector.vue
@@ -109,7 +109,7 @@ export default {
   padding: 0
   margin-top: 4px
   &-closed
-   display: none
+    display: none
   &-opened
     height: 200px
   &-item

--- a/src/.vuepress/components/SDKSelector.vue
+++ b/src/.vuepress/components/SDKSelector.vue
@@ -12,7 +12,7 @@
       >{{ currentLanguage ? currentLanguage.name : 'Select an SDK' }}</span>
       <i class="fa fa-caret-down" aria-hidden="true"></i>
     </div>
-    <ul :class="`selector-list ${isListShowed? 'selector-list-opened': ''}` ">
+    <ul :class="`selector-list selector-list-${isListShowed? 'opened': 'closed'}` ">
       <li
         class="selector-list-item"
         v-for="item in items"
@@ -108,6 +108,8 @@ export default {
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12)
   padding: 0
   margin-top: 4px
+  &-closed
+   display: none
   &-opened
     height: 200px
   &-item

--- a/src/.vuepress/components/SDKSelector.vue
+++ b/src/.vuepress/components/SDKSelector.vue
@@ -12,7 +12,7 @@
       >{{ currentLanguage ? currentLanguage.name : 'Select an SDK' }}</span>
       <i class="fa fa-caret-down" aria-hidden="true"></i>
     </div>
-    <ul class="selector-list">
+    <ul :class="`selector-list ${isListShowed? 'selector-list-opened': ''}` ">
       <li
         class="selector-list-item"
         v-for="item in items"
@@ -103,10 +103,13 @@ export default {
 .selector-list
   position: absolute
   width: 80%
+  overflow-y: scroll
   background-color: white
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12)
   padding: 0
   margin-top: 4px
+  &-opened
+    height: 200px
   &-item
     width: 100%
     list-style-type: none

--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -14,7 +14,7 @@
             <span>Kuzzle Documentation</span>
           </label>
           <TabsMobile/>
-          <SDKSelector v-if="$route.path.match(/^\/sdk\//)" :items="sdkList"/>
+          <SDKSelector class="md-sidebar--selector" v-if="$route.path.match(/^\/sdk\//)" :items="sdkList" />
           <!-- Render item list -->
           <ul class="md-nav__list" data-md-scrollfix>
             <div v-for="item__1 in getPageChildren(root)">
@@ -87,7 +87,7 @@ export default {
   data() {
     return {
       sdkList
-    }
+    };
   },
   components: {
     TabsMobile
@@ -139,5 +139,6 @@ export default {
 };
 </script>
 
-<style>
+<style lang="scss">
+
 </style>

--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -13,9 +13,8 @@
             </span>
             <span>Kuzzle Documentation</span>
           </label>
-
           <TabsMobile/>
-
+          <SDKSelector v-if="$route.path.match(/^\/sdk\//)" :items="sdkList"/>
           <!-- Render item list -->
           <ul class="md-nav__list" data-md-scrollfix>
             <div v-for="item__1 in getPageChildren(root)">
@@ -82,8 +81,14 @@
 <script>
 import TabsMobile from './TabsMobile.vue';
 import { getPageChildren, getFirstValidChild, findRootNode } from '../util.js';
+import sdkList from '../sdk.json';
 
 export default {
+  data() {
+    return {
+      sdkList
+    }
+  },
   components: {
     TabsMobile
   },

--- a/src/.vuepress/theme/TabsMobile.vue
+++ b/src/.vuepress/theme/TabsMobile.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="md-nav__source mobile-only md-nav__mobile-color">
-    <div v-if="$route.path.match('sdk-reference')" class="selector-container">
-      <SDKSelector :items="sdkList"/>
-    </div>
-
     <p class="md-nav__mobile-group-name">Use</p>
     <router-link
       :to="{path: generateLink('/core/1/guides/')}"

--- a/src/.vuepress/theme/styles/layout/_sidebar.scss
+++ b/src/.vuepress/theme/styles/layout/_sidebar.scss
@@ -16,6 +16,11 @@ $md-toggle__drawer--checked: '[data-md-toggle="drawer"]:checked ~ .md-container'
   padding: 2.4rem 0;
   overflow: hidden;
 
+  &--selector {
+    @include break-from-device(tablet landscape) {
+      display: none;
+    }
+  }
   // Hide for print
   @media print {
     display: none;

--- a/src/.vuepress/theme/styles/layout/_sidebar.scss
+++ b/src/.vuepress/theme/styles/layout/_sidebar.scss
@@ -17,6 +17,7 @@ $md-toggle__drawer--checked: '[data-md-toggle="drawer"]:checked ~ .md-container'
   overflow: hidden;
 
   &--selector {
+    margin-left: 2.4rem;
     @include break-from-device(tablet landscape) {
       display: none;
     }


### PR DESCRIPTION
## What does this PR do?
[KZL-1281](https://jira.kaliop.net/browse/KZL-1281)
Add SDK selector in sidebar

### How should this be manually tested?
  - Step 1 : npm run dev
  - Step 2 : mobile view
  - Step 3 : go to sdk page(s)

### Other changes
- set sdk selector height
- set sdk selector overflow scroll

### Boyscout
/