### PR TITLE
fix-sidebar-submenu

### DIFF
--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -33,7 +33,7 @@
                   >
                     <div v-if="getPageChildren(item__2).length">
                       <i
-                        v-if="openedSubmenu.includes(item__2.title)"
+                        v-if="openedSubmenu === item__2.title"
                         class="fa fa-caret-down"
                         aria-hidden="true"
                       ></i>
@@ -115,9 +115,7 @@ export default {
   },
   methods: {
     subMenuClass(item__1, item__2) {
-      return this.openedSubmenu.includes(
-        this.getId([item__1.title, item__2.title])
-      )
+      return this.openedSubmenu === this.getId([item__1.title, item__2.title])
         ? 'displaySubmenu'
         : '';
     },


### PR DESCRIPTION
## What does this PR do?
Fix sidebar submenu.
Bug example : 
Clicking on KuzzleEventEmitter opened KuzzleEventEmitter submenu AND Kuzzle submenu so the entries wasn't right displayed.


Bug:
![image](https://user-images.githubusercontent.com/44427849/61382512-37c55a80-a8ad-11e9-960a-8b2254455569.png)

Fix:
![image](https://user-images.githubusercontent.com/44427849/61382577-56c3ec80-a8ad-11e9-91b0-a9440f954b5a.png)


### How should this be manually tested?
  - Step 1 : npm run dev
  - Step 2 : go to sdk go
  - Step 3 : open submenu KuzzleEventEmitter


### Other changes
/

### Boyscout
/