### PR TITLE
add-a-instead-of-router-link

### DIFF
--- a/src/.vuepress/components/PluginsIndex.vue
+++ b/src/.vuepress/components/PluginsIndex.vue
@@ -28,14 +28,14 @@
       <img src="/logos/probe.svg" alt="probe listener logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Probe listener</div>
     </a>
-    <router-link :to="{path: '/official-plugins/s3/1'}" class="Tiles-item">
+    <a :href="'https://docs.kuzzle.io/official-plugins/s3/1'" class="Tiles-item">
       <img src="/logos/plugin-s3.svg" alt="amazon s3 logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Amazon S3</div>
-    </router-link>
-    <router-link :to="{path: '/official-plugins/cloudinary/1'}" class="Tiles-item">
+    </a>
+    <a :href="'https://docs.kuzzle.io/official-plugins/cloudinary/1'" class="Tiles-item">
       <img src="/logos/plugin-cloudinary.svg" alt="cloudinary logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Cloudinary</div>
-    </router-link>
+    </a>
   </div>
 </template>
 

--- a/src/.vuepress/components/PluginsIndex.vue
+++ b/src/.vuepress/components/PluginsIndex.vue
@@ -28,11 +28,11 @@
       <img src="/logos/probe.svg" alt="probe listener logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Probe listener</div>
     </a>
-    <a :href="'https://docs.kuzzle.io/official-plugins/s3/1'" class="Tiles-item">
+    <a :href="'/official-plugins/s3/1'" class="Tiles-item">
       <img src="/logos/plugin-s3.svg" alt="amazon s3 logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Amazon S3</div>
     </a>
-    <a :href="'https://docs.kuzzle.io/official-plugins/cloudinary/1'" class="Tiles-item">
+    <a :href="'/official-plugins/cloudinary/1'" class="Tiles-item">
       <img src="/logos/plugin-cloudinary.svg" alt="cloudinary logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Cloudinary</div>
     </a>

--- a/src/.vuepress/components/SDKIndex.vue
+++ b/src/.vuepress/components/SDKIndex.vue
@@ -78,8 +78,7 @@ const { getValidLinkByRootPath } = require('../util.js');
 export default {
   methods: {
     generateLink(path) {
-      return `https://docs.kuzzle.io${path}`;
-      // return getValidLinkByRootPath(path, this.$site.pages);
+      return getValidLinkByRootPath(path, this.$site.pages);
     }
   }
 };

--- a/src/.vuepress/components/SDKIndex.vue
+++ b/src/.vuepress/components/SDKIndex.vue
@@ -1,39 +1,39 @@
 <template>
   <div class="Tiles">
-    <router-link :to="{path: generateLink('/sdk/js/6/')}" class="Tiles-item">
+    <a :href="generateLink('/sdk/js/6/')" class="Tiles-item">
       <img src="/logos/javascript.svg" alt="js logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Javascript</div>
-    </router-link>
-    <router-link :to="{path: generateLink('/sdk/go/2/')}" class="Tiles-item">
+    </a>
+    <a :href="generateLink('/sdk/go/2/')" class="Tiles-item">
       <div class="ribbon">
         <span>BETA</span>
       </div>
       <img src="/logos/go.svg" alt="golang logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Golang</div>
-    </router-link>
-    <router-link :to="{path: generateLink('/sdk/cpp/1/')}" class="Tiles-item">
+    </a>
+    <a :href="generateLink('/sdk/cpp/1/')" class="Tiles-item">
       <div class="ribbon">
         <span>BETA</span>
       </div>
       <img src="/logos/cpp.svg" alt="c++ logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">C++</div>
-    </router-link>
-    <router-link :to="{path: generateLink('/sdk/java/2/')}" class="Tiles-item">
+    </a>
+    <a :href="generateLink('/sdk/java/2/')" class="Tiles-item">
       <div class="ribbon">
         <span>BETA</span>
       </div>
       <img src="/logos/java.svg" alt="java logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Java</div>
-    </router-link>
+    </a>
 
-    <router-link :to="{path: generateLink('/sdk/php/3/')}" class="Tiles-item">
+    <a :href="generateLink('/sdk/php/3/')" class="Tiles-item">
       <img src="/logos/php.svg" alt="php logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">PHP</div>
-    </router-link>
-    <router-link :to="{path: generateLink('/sdk/android/3/')}" class="Tiles-item">
+    </a>
+    <a :href="generateLink('/sdk/android/3/')" class="Tiles-item">
       <img src="/logos/android.svg" alt="android logo" class="Tiles-item-logo">
       <div class="Tiles-item-name">Android</div>
-    </router-link>
+    </a>
     <a href="https://github.com/kuzzleio/sdk-ruby" class="Tiles-item">
       <div class="ribbon">
         <span>ALPHA</span>
@@ -78,7 +78,8 @@ const { getValidLinkByRootPath } = require('../util.js');
 export default {
   methods: {
     generateLink(path) {
-      return getValidLinkByRootPath(path, this.$site.pages);
+      return `https://docs.kuzzle.io${path}`;
+      // return getValidLinkByRootPath(path, this.$site.pages);
     }
   }
 };

--- a/src/.vuepress/components/SDKSelector.vue
+++ b/src/.vuepress/components/SDKSelector.vue
@@ -17,9 +17,9 @@
         :class="getItemClass(item)"
         @click="toggleList()"
       >
-        <router-link
+        <a
           :class="`selector-list-item-link ${item.language === 'api'? 'api': ''}`"
-          :to="{path: generateLink(item)}"
+          :href="generateLink(item)"
         >
           <img
             v-if="item.language !== 'api'"
@@ -30,7 +30,7 @@
           <span
             :class="`selector-list-item-name${item.language === 'api'? '-api': ''}`"
           >{{ getSpan(item) }}</span>
-        </router-link>
+        </a>
       </li>
     </ul>
   </div>
@@ -104,7 +104,8 @@ export default {
       } else {
         path = `/sdk/${item.language}/${item.version}/${method}`;
       }
-      return getValidLinkByRootPath(path, this.$site.pages);
+      return `https://docs.kuzzle.io${path}`;
+      // return getValidLinkByRootPath(path, this.$site.pages);
     },
     toggleList: function() {
       this.isListShowed = !this.isListShowed;

--- a/src/.vuepress/components/SDKSelector.vue
+++ b/src/.vuepress/components/SDKSelector.vue
@@ -83,8 +83,6 @@ export default {
         itemClass = 'selector-list-item disabled';
       }
 
-      // let itemClass = item.language === 'api'? '': 'selector-list-item';
-      // itemClass += item.langage !== 'api' && this.generateLink(item)? '': 'disabled';
       return itemClass;
     },
     getSpan(item) {
@@ -104,8 +102,7 @@ export default {
       } else {
         path = `/sdk/${item.language}/${item.version}/${method}`;
       }
-      return `https://docs.kuzzle.io${path}`;
-      // return getValidLinkByRootPath(path, this.$site.pages);
+      return getValidLinkByRootPath(path, this.$site.pages);
     },
     toggleList: function() {
       this.isListShowed = !this.isListShowed;

--- a/src/.vuepress/theme/NotFound.vue
+++ b/src/.vuepress/theme/NotFound.vue
@@ -16,7 +16,7 @@
             <article class="md-content__inner md-typeset">
               <h1>404 Page not found</h1>
               <blockquote>{{ getMsg() }}</blockquote>
-              <a href="https://docs.kuzzle.io/">Take me home.</a>
+              <a href="/">Take me home.</a>
             </article>
           </div>
         </div>

--- a/src/.vuepress/theme/NotFound.vue
+++ b/src/.vuepress/theme/NotFound.vue
@@ -16,7 +16,7 @@
             <article class="md-content__inner md-typeset">
               <h1>404 Page not found</h1>
               <blockquote>{{ getMsg() }}</blockquote>
-              <a href="/">Take me home.</a>
+              <a :href="generateHomeLink('/')">Take me home.</a>
             </article>
           </div>
         </div>

--- a/src/.vuepress/theme/NotFound.vue
+++ b/src/.vuepress/theme/NotFound.vue
@@ -16,7 +16,7 @@
             <article class="md-content__inner md-typeset">
               <h1>404 Page not found</h1>
               <blockquote>{{ getMsg() }}</blockquote>
-              <router-link :to="generateHomeLink('/')">Take me home.</router-link>
+              <a href="https://docs.kuzzle.io/">Take me home.</a>
             </article>
           </div>
         </div>

--- a/src/.vuepress/theme/Search.vue
+++ b/src/.vuepress/theme/Search.vue
@@ -52,7 +52,7 @@
               >
                 <a
                   class="md-search-result__link"
-                  :href="`https://docs.kuzzle.io${result.path}`"
+                  :href="result.path"
                   :title="result.title"
                   :data-rt="idx === highlightedResult ? 'active' : ''"
                 >
@@ -183,11 +183,7 @@ export default {
       if (!this.results || !this.results[this.highlightedResult]) {
         return;
       }
-      window.location.href = `http://docs.kuzzle.io${this.results[this.highlightedResult].path}`;
-      // this.$router.push({
-      //   path: '/' + this.results[this.highlightedResult].path,
-      //   query: {}
-      // });
+      window.location.href = `${this.results[this.highlightedResult].path}`;
       this.reset();
     }
   },

--- a/src/.vuepress/theme/Search.vue
+++ b/src/.vuepress/theme/Search.vue
@@ -50,9 +50,9 @@
                 :key="result.path"
                 class="md-search-result__item"
               >
-                <router-link
+                <a
                   class="md-search-result__link"
-                  :to="{path: result.path}"
+                  :href="`https://docs.kuzzle.io${result.path}`"
                   :title="result.title"
                   :data-rt="idx === highlightedResult ? 'active' : ''"
                 >
@@ -70,7 +70,7 @@
                       v-html="result._highlightResult.content.value"
                     ></p>
                   </article>
-                </router-link>
+                </a>
               </li>
             </ol>
           </div>
@@ -183,10 +183,11 @@ export default {
       if (!this.results || !this.results[this.highlightedResult]) {
         return;
       }
-      this.$router.push({
-        path: '/' + this.results[this.highlightedResult].path,
-        query: {}
-      });
+      window.location.href = `http://docs.kuzzle.io${this.results[this.highlightedResult].path}`;
+      // this.$router.push({
+      //   path: '/' + this.results[this.highlightedResult].path,
+      //   query: {}
+      // });
       this.reset();
     }
   },

--- a/src/.vuepress/theme/Tabs.vue
+++ b/src/.vuepress/theme/Tabs.vue
@@ -33,7 +33,9 @@ export default {
   },
   methods: {
     getPath(link) {
-      return `https://docs.kuzzle.io${link.path}`;
+      return {
+        path: link.generateLink ? this.generateLink(link.path) : link.path
+      };
     },
     startWith(str, start) {
       return str.indexOf(start) === 0;

--- a/src/.vuepress/theme/Tabs.vue
+++ b/src/.vuepress/theme/Tabs.vue
@@ -7,12 +7,12 @@
           <p class="md-tabs__group-name">Use</p>
           <ul class="md-tabs__group-items">
             <li class="md-tabs__item" v-for="link of part">
-              <router-link
-                :to="getPath(link)"
+              <a
+                :href="getPath(link)"
                 :class="{'md-tabs__link--active': $route.path.match(link.path)}"
                 :title="link.label"
                 class="md-tabs__link"
-              >{{ link.label }}</router-link>
+              >{{ link.label }}</a>
             </li>
           </ul>
         </li>
@@ -22,8 +22,8 @@
 </template>
 
 <script>
-import { getValidLinkByRootPath } from '../util.js';
-import links from '../links.json';
+import { getValidLinkByRootPath } from "../util.js";
+import links from "../links.json";
 
 export default {
   computed: {
@@ -33,9 +33,7 @@ export default {
   },
   methods: {
     getPath(link) {
-      return {
-        path: link.generateLink ? this.generateLink(link.path) : link.path
-      };
+      return `https://docs.kuzzle.io${link.path}`;
     },
     startWith(str, start) {
       return str.indexOf(start) === 0;

--- a/src/.vuepress/theme/TabsMobile.vue
+++ b/src/.vuepress/theme/TabsMobile.vue
@@ -38,7 +38,7 @@ export default {
   },
   methods: {
     getPath(link) {
-      return `https://docs.kuzzle.io${link.path}`;
+      return {path: link.generateLink? this.generateLink(link.path): link.path};
     },
     generateLink(path) {
       return getValidLinkByRootPath(path, this.$site.pages);

--- a/src/.vuepress/theme/TabsMobile.vue
+++ b/src/.vuepress/theme/TabsMobile.vue
@@ -5,9 +5,9 @@
     </div>
     <div v-for="part of Object.keys(getLinks)">
       <p class="md-nav__mobile-group-name">{{ part }}</p>
-      <router-link
+      <a
         v-for="link of getLinks[part]"
-        :to="getPath(link)"
+        :href="getPath(link)"
         :title="link.label"
         class="md-source"
         data-md-state="done"
@@ -15,7 +15,7 @@
         @click.native="$emit('closeSidebar')"
       >
         <div class="md-source__repository">{{ link.label }} </div>
-      </router-link>
+      </a>
     </div>
   </div>
 </template>
@@ -38,7 +38,7 @@ export default {
   },
   methods: {
     getPath(link) {
-      return {path: link.generateLink? this.generateLink(link.path): link.path};
+      return `https://docs.kuzzle.io${link.path}`;
     },
     generateLink(path) {
       return getValidLinkByRootPath(path, this.$site.pages);


### PR DESCRIPTION
## What does this PR do?
Replace `router-link` by `a href` in:
Tabs
Tabs Mobile
SDK Selector
Algolia Search
SDK Index
Plugins Index