### PR TITLE
always redirect to home page

### DIFF
--- a/src/.vuepress/components/SDKSelector.vue
+++ b/src/.vuepress/components/SDKSelector.vue
@@ -98,17 +98,17 @@ export default {
     generateLink(item) {
       let method = '';
       let path = '';
-      if (this.$route.path.includes('controllers')) {
-        method = `controllers/${this.$route.path.split('controllers/')[1]}`;
-      }
+      // if (this.$route.path.includes('controllers')) {
+      //   method = `controllers/${this.$route.path.split('controllers/')[1]}`;
+      // }
       if (item.language === 'api') {
         path = '/core/1/api/';
       } else {
         path = `/sdk/${item.language}/${item.version}/`;
       }
-      if (!this.oldSDK.includes(`${item.language}${item.version}`)) {
-        path += method;
-      }
+      // if (!this.oldSDK.includes(`${item.language}${item.version}`)) {
+      //   path += method;
+      // }
       return path;
     },
     toggleList: function() {


### PR DESCRIPTION
## What does this PR do?

Actually, the SDK Selector can redirect an user from api controller method to sdk controller method. But there is a bug and the user is immediatly redirect to a wrong url.

This pr avoid the possibility to go to the same method (api -> sdk | sdk -> api) by automatically redirect to home page of sdk/api (ex: api/essentials/connecting-to-kuzzle), to fix the bug until we resolve it.
