### PR TITLE
Fix command devServer from the CLI for repositories 

### DIFF
--- a/.repos/repositories.js
+++ b/.repos/repositories.js
@@ -134,10 +134,11 @@ const devServer = async (argv) => {
   for (const repository of getRepositories(argv)) {
     const
       message = `Link build from repository ${repository.name}`,
-      linkTarget = `../../../../.repos/${repository.destination}/doc/framework/src/.vuepress/dist`,
+      linkTarget = `${currentDir}/${repository.destination}/doc/framework/src/.vuepress/dist/`,
       linkName = `${currentDir}/../src/.vuepress/dist${repository.base_url}`,
-      command = `rm -f ${linkName} && ln -s ${linkTarget} ${linkName}`;
+      command = `rm -rf ${linkName} && ln -s ${linkTarget} ${linkName}`;
 
+    await execute(`mkdir -p ${currentDir}/../src/.vuepress/dist${repository.base_url}`, 'Creating subfolders');
     await execute(command, message);
   }
 


### PR DESCRIPTION
## What does this PR do?

A little fix for the command devServer from the CLI for repositories, which allows to simulate the documentation in a production environment by running repos built separately on the same server
It can be useful to debug some issues that are present in production and not in local.

@Aschen you might want to test it

### How should this be manually tested?

  - Step 1 : `cd .repos/`
  - Step 2 : `node repositories prepare`
  - Step 3 : `node repositories build`
  - Step 4 : `node repositories devServer`
  - Step 5 : Go to http://localhost:8000

Note : You don't have to build all repositories. Since it takes a long time to build everything, you can chose which you want to build :
For instance, if you need just the `core` and the `js6 sdk`, the command will be : 
`node repositories build --repo kuzzle-1 --repo sdk-javascript-6 --async`