### PR TITLE
WIP: update title on 404 pages

### DIFF
--- a/src/.vuepress/theme/NotFound.vue
+++ b/src/.vuepress/theme/NotFound.vue
@@ -64,6 +64,9 @@ export default {
     }
   },
   mounted() {
+    // We need to change the title of page 404
+    // to follow dead links with google analytics
+    document.title = 'Page not found | Kuzzle Docs'
     this.setContainerPadding();
   }
 };


### PR DESCRIPTION
## What does this PR do?
Because we use page title on google analytics to track dead links, we need to change this title on 404 pages.