### PR TITLE
[markdown] Fixed router-link generation

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": true
+}

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -246,6 +246,7 @@ module.exports = {
     extendMarkdown: md => {
       md.use(require('./markdown/code-snippet'));
       md.use(require('./markdown/copy-paste-snippet-btn'));
+      md.use(require('./markdown/link')({ base }));
     }
   },
   configureWebpack: {

--- a/src/.vuepress/markdown/link.js
+++ b/src/.vuepress/markdown/link.js
@@ -12,8 +12,8 @@ module.exports = (configuration) => {
     let hasOpenExternalLink = false
 
     md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-    const { base } = configuration;
-    const { relativePath } = env
+      const { base } = configuration
+      const { relativePath } = env
       const token = tokens[idx]
       const hrefIndex = token.attrIndex('href')
       if (hrefIndex >= 0) {

--- a/src/.vuepress/markdown/link.js
+++ b/src/.vuepress/markdown/link.js
@@ -2,94 +2,92 @@
 // 1. adding target="_blank" to external links
 // 2. converting internal links to <router-link>
 
-const url = require('url')
+const url = require('url');
 
-const indexRE = /(^|.*\/)(index|readme).md(#?.*)$/i
+const indexRE = /(^|.*\/)(index|readme).md(#?.*)$/i;
 
-module.exports = (configuration) => {
-  return (md) => {
-    let hasOpenRouterLink = false
-    let hasOpenExternalLink = false
+module.exports = configuration => {
+  return md => {
+    let hasOpenRouterLink = false;
+    let hasOpenExternalLink = false;
 
     md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-      const { base } = configuration
-      const { relativePath } = env
-      const token = tokens[idx]
-      const hrefIndex = token.attrIndex('href')
+      const { base } = configuration;
+      const { relativePath } = env;
+      const token = tokens[idx];
+      const hrefIndex = token.attrIndex('href');
       if (hrefIndex >= 0) {
-        const link = token.attrs[hrefIndex]
-        const href = link[1]
-        const isExternal = /^https?:/.test(href)
-        const startsWithBaseURL = href.startsWith(base)
-        
+        const link = token.attrs[hrefIndex];
+        const href = link[1];
+        const isExternal = /^https?:/.test(href);
+        const startsWithBaseURL = href.startsWith(base);
+
         if (isExternal) {
-          hasOpenExternalLink = true
-          token.attrSet('target', '_blank')
-          token.attrSet('rel', 'noopener noreferrer')
+          hasOpenExternalLink = true;
+          token.attrSet('target', '_blank');
+          token.attrSet('rel', 'noopener noreferrer');
         } else if (startsWithBaseURL) {
-          hasOpenRouterLink = true
-          tokens[idx] = toRouterLink(token, link, relativePath, base)
+          hasOpenRouterLink = true;
+          tokens[idx] = toRouterLink(token, link, relativePath, base);
         }
       }
-      return self.renderToken(tokens, idx, options)
-    }
+      return self.renderToken(tokens, idx, options);
+    };
 
     function toRouterLink(token, link, relativePath, base) {
-      link[0] = 'to'
-      let to = link[1].replace(base, '')
+      link[0] = 'to';
+      let to = link[1].replace(base, '');
 
       // convert link to filename and export it for existence check
-      const links = md.$data.links || (md.$data.links = [])
-      links.push(to)
+      const links = md.$data.links || (md.$data.links = []);
+      links.push(to);
 
       // relative path usage.
       if (!to.startsWith('/')) {
         to = relativePath
           ? url.resolve('/' + relativePath, to)
-          : ensureBeginningDotSlash(to)
+          : ensureBeginningDotSlash(to);
       }
 
-      const indexMatch = to.match(indexRE)
+      const indexMatch = to.match(indexRE);
       if (indexMatch) {
-        const [, path, , hash] = indexMatch
-        to = path + hash
+        const [, path, , hash] = indexMatch;
+        to = path + hash;
       } else {
-        to = to
-          .replace(/\.md$/, '.html')
-          .replace(/\.md\/?(#.*)$/, '.html$1')
+        to = to.replace(/\.md$/, '.html').replace(/\.md\/?(#.*)$/, '.html$1');
       }
 
       // markdown-it encodes the uri
-      link[1] = decodeURI(to)
+      link[1] = decodeURI(to);
 
       // export the router links for testing
-      const routerLinks = md.$data.routerLinks || (md.$data.routerLinks = [])
-      routerLinks.push(to)
+      const routerLinks = md.$data.routerLinks || (md.$data.routerLinks = []);
+      routerLinks.push(to);
 
       return Object.create(token, {
         tag: { value: 'router-link' }
-      })
+      });
     }
 
     md.renderer.rules.link_close = (tokens, idx, options, env, self) => {
-      const token = tokens[idx]
+      const token = tokens[idx];
       if (hasOpenRouterLink) {
-        token.tag = 'router-link'
-        hasOpenRouterLink = false
+        token.tag = 'router-link';
+        hasOpenRouterLink = false;
       }
       if (hasOpenExternalLink) {
-        hasOpenExternalLink = false
+        hasOpenExternalLink = false;
         // add OutBoundLink to the beforeend of this link if it opens in _blank.
-        return '<OutboundLink/>' + self.renderToken(tokens, idx, options)
+        return '<OutboundLink/>' + self.renderToken(tokens, idx, options);
       }
-      return self.renderToken(tokens, idx, options)
-    }
-  }
-}
+      return self.renderToken(tokens, idx, options);
+    };
+  };
+};
 
 function ensureBeginningDotSlash(path) {
   if (path.startsWith('./')) {
-    return path
+    return path;
   }
-  return './' + path
+  return './' + path;
 }

--- a/src/.vuepress/markdown/link.js
+++ b/src/.vuepress/markdown/link.js
@@ -13,8 +13,6 @@ module.exports = (configuration) => {
 
     md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
     const { base } = configuration;
-    const startsWithBaseRE = new RegExp(`^${base}.*`)
-    const internalRE = /(\/|\.md|\.html)(#.*)?$/
     const { relativePath } = env
       const token = tokens[idx]
       const hrefIndex = token.attrIndex('href')
@@ -22,14 +20,13 @@ module.exports = (configuration) => {
         const link = token.attrs[hrefIndex]
         const href = link[1]
         const isExternal = /^https?:/.test(href)
-        const isInternal = internalRE.test(href)
-        const startsWithBaseURL = startsWithBaseRE.test(href)
+        const startsWithBaseURL = href.startsWith(base)
         
         if (isExternal) {
           hasOpenExternalLink = true
           token.attrSet('target', '_blank')
           token.attrSet('rel', 'noopener noreferrer')
-        } else if (isInternal && startsWithBaseURL) {
+        } else if (startsWithBaseURL) {
           hasOpenRouterLink = true
           tokens[idx] = toRouterLink(token, link, relativePath, base)
         }
@@ -90,10 +87,8 @@ module.exports = (configuration) => {
   }
 }
 
-const beginningSlashRE = /^\.\//
-
 function ensureBeginningDotSlash(path) {
-  if (beginningSlashRE.test(path)) {
+  if (path.startsWith('./')) {
     return path
   }
   return './' + path

--- a/src/.vuepress/markdown/link.js
+++ b/src/.vuepress/markdown/link.js
@@ -1,0 +1,100 @@
+// markdown-it plugin for:
+// 1. adding target="_blank" to external links
+// 2. converting internal links to <router-link>
+
+const url = require('url')
+
+const indexRE = /(^|.*\/)(index|readme).md(#?.*)$/i
+
+module.exports = (configuration) => {
+  return (md) => {
+    let hasOpenRouterLink = false
+    let hasOpenExternalLink = false
+
+    md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    const { base } = configuration;
+    const startsWithBaseRE = new RegExp(`^${base}.*`)
+    const internalRE = /(\/|\.md|\.html)(#.*)?$/
+    const { relativePath } = env
+      const token = tokens[idx]
+      const hrefIndex = token.attrIndex('href')
+      if (hrefIndex >= 0) {
+        const link = token.attrs[hrefIndex]
+        const href = link[1]
+        const isExternal = /^https?:/.test(href)
+        const isInternal = internalRE.test(href)
+        const startsWithBaseURL = startsWithBaseRE.test(href)
+        
+        if (isExternal) {
+          hasOpenExternalLink = true
+          token.attrSet('target', '_blank')
+          token.attrSet('rel', 'noopener noreferrer')
+        } else if (isInternal && startsWithBaseURL) {
+          hasOpenRouterLink = true
+          tokens[idx] = toRouterLink(token, link, relativePath, base)
+        }
+      }
+      return self.renderToken(tokens, idx, options)
+    }
+
+    function toRouterLink(token, link, relativePath, base) {
+      link[0] = 'to'
+      let to = link[1].replace(base, '')
+
+      // convert link to filename and export it for existence check
+      const links = md.$data.links || (md.$data.links = [])
+      links.push(to)
+
+      // relative path usage.
+      if (!to.startsWith('/')) {
+        to = relativePath
+          ? url.resolve('/' + relativePath, to)
+          : ensureBeginningDotSlash(to)
+      }
+
+      const indexMatch = to.match(indexRE)
+      if (indexMatch) {
+        const [, path, , hash] = indexMatch
+        to = path + hash
+      } else {
+        to = to
+          .replace(/\.md$/, '.html')
+          .replace(/\.md(#.*)$/, '.html$1')
+      }
+
+      // markdown-it encodes the uri
+      link[1] = decodeURI(to)
+
+      // export the router links for testing
+      const routerLinks = md.$data.routerLinks || (md.$data.routerLinks = [])
+      routerLinks.push(to)
+
+      return Object.create(token, {
+        tag: { value: 'router-link' }
+      })
+    }
+
+    md.renderer.rules.link_close = (tokens, idx, options, env, self) => {
+      const token = tokens[idx]
+      if (hasOpenRouterLink) {
+        token.tag = 'router-link'
+        hasOpenRouterLink = false
+      }
+      if (hasOpenExternalLink) {
+        hasOpenExternalLink = false
+        // add OutBoundLink to the beforeend of this link if it opens in _blank.
+        return '<OutboundLink/>' + self.renderToken(tokens, idx, options)
+      }
+      return self.renderToken(tokens, idx, options)
+    }
+  }
+}
+
+const beginningSlashRE = /^\.\//
+
+function ensureBeginningDotSlash(path) {
+  if (beginningSlashRE.test(path)) {
+    return path
+  }
+  return './' + path
+}

--- a/src/.vuepress/markdown/link.js
+++ b/src/.vuepress/markdown/link.js
@@ -56,7 +56,7 @@ module.exports = (configuration) => {
       } else {
         to = to
           .replace(/\.md$/, '.html')
-          .replace(/\.md(#.*)$/, '.html$1')
+          .replace(/\.md\/?(#.*)$/, '.html$1')
       }
 
       // markdown-it encodes the uri


### PR DESCRIPTION
Now MD links are translated to `router-link` only if their `href` starts with the provided `base` URL.