### PR TITLE
[ui] No more superimposed titles in secondary menu

### DIFF
--- a/src/.vuepress/theme/Layout.vue
+++ b/src/.vuepress/theme/Layout.vue
@@ -1,8 +1,16 @@
 <template>
   <div class="md-layout">
     <div class="overlayLoading" v-if="isLoading" />
-    <div class="overlay" :class="{ hidden: !sidebarOpen }" @click="closeSidebar"></div>
-    <Header ref="header" @openSidebar="openSidebar" @kuzzle-major-changed="changeKuzzleMajor" />
+    <div
+      class="overlay"
+      :class="{ hidden: !sidebarOpen }"
+      @click="closeSidebar"
+    ></div>
+    <Header
+      ref="header"
+      @openSidebar="openSidebar"
+      @kuzzle-major-changed="changeKuzzleMajor"
+    />
 
     <div ref="container" class="md-container">
       <!-- Main container -->
@@ -16,11 +24,15 @@
             :kuzzleMajor="kuzzleMajor"
           />
           <!-- Table of contents -->
-          <div ref="toc" class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+          <div
+            ref="toc"
+            class="md-sidebar md-sidebar--secondary"
+            data-md-component="toc"
+          >
             <div class="md-sidebar__scrollwrap">
               <div class="md-sidebar__inner">
                 <div v-if="sdkOrApiPage" class="selector-container">
-                  <SDKSelector :items="sdkList" :kuzzzleMajor="kuzzleMajor" />
+                  <SDKSelector :items="sdkList" :kuzzleMajor="kuzzleMajor" />
                 </div>
                 <TOC />
               </div>

--- a/src/.vuepress/theme/TOC.vue
+++ b/src/.vuepress/theme/TOC.vue
@@ -4,10 +4,15 @@
       <label class="md-nav__title" for="toc">Table of contents</label>
       <ul class="md-nav__list" data-md-scrollfix>
         <li class="md-nav__item">
-          <a :title="$page.title" class="md-nav__link">{{$page.title}}</a>
+          <a :title="$page.title" class="md-nav__link">{{ $page.title }}</a>
         </li>
         <li v-for="header of headers" class="md-nav__item">
-          <a :href="getPath(header)" :title="header.title" class="md-nav__link">{{header.title}}</a>
+          <a
+            :href="getPath(header)"
+            :title="header.title"
+            class="md-nav__link"
+            >{{ header.title }}</a
+          >
         </li>
       </ul>
     </nav>
@@ -32,5 +37,4 @@ export default {
 };
 </script>
 
-<style>
-</style>
+<style></style>

--- a/src/.vuepress/theme/styles/layout/_nav.scss
+++ b/src/.vuepress/theme/styles/layout/_nav.scss
@@ -17,10 +17,9 @@
       @include break-to-device(tablet) {
         padding: 2px 0 0 12px !important;
         border-top: none !important;
-        border-bottom: .1rem solid rgba(0,0,0,.07);
-        margin-bottom: 5px
+        border-bottom: 0.1rem solid rgba(0, 0, 0, 0.07);
+        margin-bottom: 5px;
       }
-    
     }
 
     .md-nav__item {
@@ -132,13 +131,11 @@
       margin-bottom: 5px !important;
       padding-left: 12px;
     }
-    
   }
 
   // List item
   &__item {
     padding: 5px 1.2rem;
-    height: 30px;
 
     // Add bottom spacing to last item
     &:last-child {


### PR DESCRIPTION
## What does this PR do?

<h3>Before </h3>

![Menu secondary before](https://user-images.githubusercontent.com/55242479/74444204-cc5c5f00-4e74-11ea-8b39-c8cefa8fc0f3.png)

<h3>After </h3>

![Menu secondary after](https://user-images.githubusercontent.com/55242479/74444241-de3e0200-4e74-11ea-82d4-ec862be85a9f.png)


### Boyscout

Correction of a "Kuzzzle".
