### PR TITLE
[KZL-1482] Tab support in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ You can learn more about the linter by looking at its [official repository](http
 
 ## Custom containers
 
+### alert/info boxes
+
 You can create alert/info boxes in your markdown with the following syntax:
 
 ```markdown
@@ -154,6 +156,21 @@ lorem ipsum
 ```
 
 Supported containers are : `info`, `success`, `warning`
+
+### Tabs
+
+It is possible to add tabs directly in the markdown with this syntax:
+
+```markdown
+:::: tabs
+::: tab yourTabName
+<<< ./snippets/check-token.java
+:::
+::: tab anotherTab
+<<< ./snippets/check-token.kt
+:::
+::::
+```
 
 ## Code snippet import
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12492,6 +12492,11 @@
         "loader-utils": "^1.0.2"
       }
     },
+    "vue-tabs-component": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vue-tabs-component/-/vue-tabs-component-1.5.0.tgz",
+      "integrity": "sha512-ld4p+hv49Fimw+zv/7GQqMhbjAHjpbWF3UiJtmMaSnvLKbsB1ysfs9dQH0SZ8NvdYpqqKay/VLIqR9yXgse1Sg=="
+    },
     "vue-template-compiler": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
@@ -12639,6 +12644,11 @@
       "requires": {
         "smoothscroll-polyfill": "^0.4.3"
       }
+    },
+    "vuepress-plugin-tabs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-tabs/-/vuepress-plugin-tabs-0.3.0.tgz",
+      "integrity": "sha512-jooDlcMdBqhXgIaF1awFSaOTM56mleP6bbCiGxyQxTZexfvCfDvZhNLGpyXqMQA50ZmNGmvLrK82YYb63k1jfA=="
     },
     "warning-symbol": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
     "read-yaml": "^1.1.0",
     "sanitize-filename": "^1.6.1",
     "sass-loader": "^7.1.0",
+    "vue-tabs-component": "^1.5.0",
     "vuepress": "1.0.1",
     "vuepress-frontmatter-lint": "^2.1.2",
     "vuepress-plugin-container": "^2.0.1",
+    "vuepress-plugin-tabs": "^0.3.0",
     "yargs": "^13.3.0"
   },
   "devDependencies": {

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -255,7 +255,8 @@ module.exports = {
     plugins: [
       new webpack.DefinePlugin({
         GA_ID:
-          JSON.stringify(process.env.GA_ID) || JSON.stringify(googleAnalyticsID),
+          JSON.stringify(process.env.GA_ID) ||
+          JSON.stringify(googleAnalyticsID),
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         'process.env.RESET_APP_DATA_TIMER': JSON.stringify(
           process.env.RESET_APP_DATA_TIMER
@@ -276,18 +277,19 @@ module.exports = {
     ]
   },
   plugins: [
+    'tabs',
     require('./meta-tags-plugin/index.js'),
     process.env.ALGOLIA_WRITE_KEY && !process.env.DISABLE_ALGOLIA
       ? [
-        require('./index-to-algolia/index.js'),
-        {
-          algoliaAppId: process.env.ALGOLIA_APP_ID || algoliaDefaultAppId,
-          algoliaWriteKey: process.env.ALGOLIA_WRITE_KEY,
-          algoliaIndex: process.env.ALGOLIA_INDEX || algoliaDefaultIndex,
-          clearIndex: process.env.ALGOLIA_CLEAR_INDEX,
-          repoName: process.env.REPO_NAME
-        }
-      ]
+          require('./index-to-algolia/index.js'),
+          {
+            algoliaAppId: process.env.ALGOLIA_APP_ID || algoliaDefaultAppId,
+            algoliaWriteKey: process.env.ALGOLIA_WRITE_KEY,
+            algoliaIndex: process.env.ALGOLIA_INDEX || algoliaDefaultIndex,
+            clearIndex: process.env.ALGOLIA_CLEAR_INDEX,
+            repoName: process.env.REPO_NAME
+          }
+        ]
       : {},
     [
       require('vuepress-frontmatter-lint'),

--- a/src/.vuepress/theme/styles/layout/_sdk-tabs.scss
+++ b/src/.vuepress/theme/styles/layout/_sdk-tabs.scss
@@ -1,0 +1,38 @@
+.tabs-component {
+  &-tabs {
+    margin: 0 !important;
+    border: 0;
+  }
+
+  &-tab {
+    margin: 0 0 0 0 !important;
+    background-color: #fff;
+    transition: transform 0.3s ease;
+    list-style: none;
+    display: inline-block;
+    width: 5em;
+    text-align: center;
+    a {
+      color: rgba(233, 78, 119, 0.8);
+      &:hover {
+        color: rgba(233, 78, 119, 1);
+      }
+    }
+    &.is-active {
+      margin: 0 0 0 0 !important;
+      border-bottom: solid 5px rgba(233, 78, 119, 0.8);
+      a {
+        color: $md-color-primary;
+      }
+    }
+  }
+
+  &-panels {
+    border-top-left-radius: 0;
+    background-color: #fff;
+    border: solid 1px #ddd;
+    border-radius: 0 6px 6px 6px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+    padding: 1em 1em;
+  }
+}

--- a/src/.vuepress/theme/styles/layout/_sdk-tabs.scss
+++ b/src/.vuepress/theme/styles/layout/_sdk-tabs.scss
@@ -1,11 +1,15 @@
+@mixin reset-margin {
+  margin: 0 0 0 0 !important;
+}
+
 .tabs-component {
   &-tabs {
-    margin: 0 0 0 0 !important;
+    @include reset-margin;
     border: 0;
   }
 
   &-tab {
-    margin: 0 0 0 0 !important;
+    @include reset-margin;
     background-color: #fff;
     transition: transform 0.3s ease;
     list-style: none;

--- a/src/.vuepress/theme/styles/layout/_sdk-tabs.scss
+++ b/src/.vuepress/theme/styles/layout/_sdk-tabs.scss
@@ -1,6 +1,6 @@
 .tabs-component {
   &-tabs {
-    margin: 0 !important;
+    margin: 0 0 0 0 !important;
     border: 0;
   }
 
@@ -12,6 +12,7 @@
     display: inline-block;
     width: 5em;
     text-align: center;
+    border-bottom: solid 4px white;
     a {
       color: rgba(233, 78, 119, 0.8);
       &:hover {
@@ -19,7 +20,7 @@
       }
     }
     &.is-active {
-      margin: 0 0 0 0 !important;
+      margin: 0 0 0 0;
       border-bottom: solid 5px rgba(233, 78, 119, 0.8);
       a {
         color: $md-color-primary;

--- a/src/.vuepress/theme/styles/main.scss
+++ b/src/.vuepress/theme/styles/main.scss
@@ -47,6 +47,7 @@
 @import 'layout/tabs';
 @import 'layout/versions';
 @import 'layout/sdk-selector';
+@import 'layout/sdk-tabs';
 
 @import 'extensions/admonition';
 @import 'extensions/codehilite';


### PR DESCRIPTION
## What does this PR do?
Allows to add tabs for code snippets directly in the markdown of the documentation
```
Some markdown content...

## Usage

:::: tabs
::: tab Java
<<< ./snippets/check-token.java
:::
::: tab Kotlin
<<< ./snippets/check-token.kt
:::
::::
```

![image](https://user-images.githubusercontent.com/3192870/77563243-4abf0e80-6ec1-11ea-877c-572d05ed8f73.png)

