### PR TITLE
Allow to hide deprecated content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,13 @@ jobs:
       name: sdk-java-2
 
     # ----------------------------
+    # SDK Java v3
+    # ----------------------------
+    - <<: *doc-deploy-base
+      <<: *doc-deploy-content
+      name: sdk-java-3
+
+    # ----------------------------
     # SDK Android v3
     # ----------------------------
     - <<: *doc-deploy-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,13 +137,6 @@ jobs:
       name: sdk-java-2
 
     # ----------------------------
-    # SDK Java v3
-    # ----------------------------
-    - <<: *doc-deploy-base
-      <<: *doc-deploy-content
-      name: sdk-java-3
-
-    # ----------------------------
     # SDK Android v3
     # ----------------------------
     - <<: *doc-deploy-base

--- a/src/.vuepress/components/DeprecatedBadge.vue
+++ b/src/.vuepress/components/DeprecatedBadge.vue
@@ -1,11 +1,17 @@
 <template>
-  <Badge type="error" :text="`Deprecated since ${version}`" />
+  <div>
+    <details v-if="this.$slots.default">
+      <summary><Badge type="error" :text="`Deprecated since ${version}`"/></summary>
+      <slot></slot>
+    </details>
+    <Badge v-else type="error" :text="`Deprecated since ${version}`"/>
+  </div>
 </template>
 
 <script>
 import Badge from '@vuepress/theme-default/global-components/Badge.vue';
+
 export default {
-  name: 'DeprecatedBadge',
   components: {
     Badge
   },
@@ -18,4 +24,5 @@ export default {
 };
 </script>
 
-<style></style>
+<style>
+</style>


### PR DESCRIPTION
## What does this PR do?

We have many deprecated content because we try to avoid breaking changes.

Those deprecated features should not be used anymore and thus we don't want them to pollute the documentation pages. 

This PR improve the `DeprecatedBadge` component to allows it to take a [Vue.js slot](https://vuejs.org/v2/guide/components-slots.html).   

All documentation encapsulated inside the `DeprecatedBadge` will be collapsed by default but the user can still expand this content by clicking on it.  

See https://trello.com/c/Q4e5aGhd/273-seb-collapse-deprecated-parts-in-the-documentation

```
### Optional:

<SinceBadge version="2.1.0"/>

* `settings`: Elasticsearch index [settings](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/index-modules.html#index-modules-settings)
* `mappings`: [collection mappings](/core/2/guides/essentials/database-mappings)

<DeprecatedBadge version="2.1.0">

* `dynamic`: [dynamic mapping policy](/core/2/guides/essentials/database-mappings#dynamic-mapping-policy) for new fields. Allowed values: `true` (default), `false`, `strict`
* `_meta`: [collection additional metadata](/core/2/guides/essentials/database-mappings#collection-metadata) stored next to the collection
* `properties`: object describing the data mapping to associate to the new collection, using [Elasticsearch types definitions format](/core/2/guides/essentials/database-mappings#properties-types-definition)

</DeprecatedBadge>
```

![deprecated](https://user-images.githubusercontent.com/4447392/78964644-2edf7d80-7afb-11ea-8bdc-6c85a879a6d0.gif)


Also, it's still possible to only display a `DeprecatedBadge` without content:
```
| Name |Type | Options |
|----- | ----- | ----- |
| `settings` | <pre>String</pre> | Collection settings <DeprecatedBadge version="1.4.1" /> |
```
![image](https://user-images.githubusercontent.com/4447392/78964481-9ba64800-7afa-11ea-95e3-c29743442417.png)

