### PR TITLE
[fix] Algolia logo source and size

### DIFF
--- a/src/.vuepress/theme/Search.vue
+++ b/src/.vuepress/theme/Search.vue
@@ -45,7 +45,7 @@
             <div class="md-search-result__meta">
               <img
                 v-if="results === null || results.length === 0"
-                src="https://www.algolia.com/assets/pricing_new/algolia-powered-by-ac7dba62d03d1e28b0838c5634eb42a9.svg"
+                src="https://res.cloudinary.com/hilnmyskv/image/upload/search-by-algolia.svg"
                 alt="Search by Algolia"
                 class="algolia-logo"
               />

--- a/src/.vuepress/theme/styles/layout/_search.scss
+++ b/src/.vuepress/theme/styles/layout/_search.scss
@@ -436,6 +436,7 @@ $md-toggle__search--checked: '[data-md-toggle="search"]:checked ~ .md-header';
     .algolia-logo {
       position: relative;
       top: 5px;
+      max-width: 13rem;
     }
 
     // [tablet landscape +]: Increase left indent


### PR DESCRIPTION
## What does this PR do?
Updates the currently broken algolia logo in the search bar with a newly more stable url from the [algolia community assets.](https://community.algolia.com/design/?q=algolia&hPP=300&idx=algolia-assets&p=0&is_v=1)

![image](https://user-images.githubusercontent.com/2495908/85869572-2890a180-b7cc-11ea-9a74-219069e91f30.png)
![image](https://user-images.githubusercontent.com/2495908/85869590-30e8dc80-b7cc-11ea-9b32-4a51d86c87c1.png)
![image](https://user-images.githubusercontent.com/2495908/85869603-36debd80-b7cc-11ea-8b6d-144b8e7baf47.png)

closes #439