### PR TITLE
New documentation structure development scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dead-links": "ruby .ci/dead-links.rb -p src/",
     "doc-upload": "aws s3 sync src/.vuepress/dist s3://$S3_BUCKET",
     "doc-cloudfront": "aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths '/*'",
-    "doc-deploy": "npm run upload && npm run cloudfront"
+    "doc-deploy": "npm run upload && npm run cloudfront",
+    "doc:new:install": "REPOSITORIES=kuzzle-2 kuzdoc iterate-repos:install && cd .repos/kuzzle-2/ && git checkout -b doc-new-architecture && git pull origin doc-new-architecture",
+    "doc:new:run": "cd .repos/kuzzle-2/ && git pull origin doc-new-architecture && cd - && npm run doc-dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What does this PR do?

This PR is intended to works with other repositories and the new documentation structure.

Checkout the branch and then run: `npm run doc:new:install`

Then you can run the preview with: `npm run doc:new:dev`

When you make an update on another repository you have to run the same command again.

:warning: You have to work on the corresponding repositories and push your modifications when you change change the structure
 - Kuzzle: https://github.com/kuzzleio/kuzzle/pull/1708