### PR TITLE
Add Netlify config with NODE_OPTIONS environment var

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+  NODE_OPTIONS = "--max_old_space_size=4096"


### PR DESCRIPTION
## What does this PR do?
Since we upgraded the Vuepress version, Netlify preview builds fail all the time. In order to fix this problem on all repositories that need documentation, without downgrading, the best solution seems to be this configuration file.

This one just specifies: `NODE_OPTIONS = "--max_old_space_size=4096"`


