### PR TITLE
Allow to end a specific snippet inside another snippet

### DIFF
--- a/src/.vuepress/markdown/code-snippet.js
+++ b/src/.vuepress/markdown/code-snippet.js
@@ -127,7 +127,7 @@ function generateSnippetRegex(snippetId) {
   }
 
   return new RegExp(
-    `^.*snippet:start${snippetId}.*$\\n((.|\\n)*?)^.*snippet:end.*$\\n`,
+    `^.*snippet:start${snippetId}.*$\\n((.|\\n)*?)^.*(snippet:end |snippet:end${snippetId}).*$\\n`,
     'gm'
   );
 }


### PR DESCRIPTION
## What does this PR do?

Allow to end a snippet inside another snippet by using its number to end.

```dart
import 'package:flutter/material.dart';
/* snippet:start:1 */
class Main {
  /* snippet:start:2 */
  final foo = 'Foo';
  /* snippet:end:2 */
}
/* snippet:end */
```
