### PR TITLE
Add custom table component

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ It is possible to add tabs directly in the markdown with this syntax:
 ::::
 ```
 
+### Custom table
+
+Use the custom table component directly in the markdown like this :
+
+```
+<CustomTable :items="...">
+```
+
+`items` props format :
+
+```
+[
+  {
+    icon: 'path/to/your/img',
+    text: 'the text you want',
+    href: 'url' (not required)
+  },
+  {
+    ...
+  }
+]
+```
+each object of the array corresponds to a cell of the custom table
+
 ## Code snippet import
 
 You can [import code snippets from file](https://v1.vuepress.vuejs.org/guide/markdown.html#import-code-snippets), as supported by VuePress, with the following syntax in your Markdown:

--- a/src/.vuepress/components/CustomTable.vue
+++ b/src/.vuepress/components/CustomTable.vue
@@ -62,7 +62,7 @@ export default {
     width: 60px;
     height: 60px;
 
-    .img {
+    img {
       width: 100%;
     }
   }
@@ -74,6 +74,19 @@ export default {
     overflow: hidden;
     width: calc(100% - 5em);
     height: calc(100% - 2em);
+  }
+}
+
+@media (max-width: 720px) {
+  .CustomTable-item {
+    background-color: white;
+    display: block;
+    width: 100%;
+    border-right: 1px solid #e1e4e5;
+
+    &:nth-child(odd) {
+      background-color: #eee;
+    }
   }
 }
 </style>

--- a/src/.vuepress/components/CustomTable.vue
+++ b/src/.vuepress/components/CustomTable.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="CustomTable">
+    <div class="CustomTable-item" v-for="item in items">
+      <div class="CustomTable-item-icon">
+        <img :src="item.icon" alt="" v-if="item.icon" />
+      </div>
+      <div class="CustomTable-item-text">
+        <template v-if="item.href">
+          <a :href="item.href">{{ item.text }}</a>
+        </template>
+        <template v-else>
+          {{ item.text }}
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CustomTable',
+  props: {
+    items: {
+      type: Array,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.CustomTable {
+  width: 100%;
+  padding: 1em;
+
+  &-item {
+    display: inline-block;
+    width: 50%;
+    height: 6em;
+    border-left: 1px solid #e1e4e5;
+    border-bottom: 1px solid #e1e4e5;
+    padding: 1em;
+    background-color: #eee;
+
+    &:nth-child(-n + 2) {
+      border-top: 1px solid #e1e4e5;
+    }
+
+    &:nth-child(even) {
+      border-right: 1px solid #e1e4e5;
+    }
+
+    &:nth-child(4n),
+    &:nth-child(4n-1) {
+      background-color: white;
+    }
+  }
+
+  &-item-icon {
+    display: table-cell;
+    vertical-align: middle;
+    width: 60px;
+    height: 60px;
+
+    .img {
+      width: 100%;
+    }
+  }
+
+  &-item-text {
+    display: table-cell;
+    vertical-align: middle;
+    padding-left: 1em;
+    overflow: hidden;
+    width: calc(100% - 5em);
+    height: calc(100% - 2em);
+  }
+}
+</style>


### PR DESCRIPTION
# What does this PR do?
Add custom table component

<img width="808" alt="Capture d’écran 2020-10-20 à 16 41 32" src="https://user-images.githubusercontent.com/3192870/96602615-7e490680-12f3-11eb-8c24-6a29150f3fd2.png">

Use the custom table component directly in the markdown like this :

```
<CustomTable :items="...">
```

`items` props format :

```
[
  {
    icon: 'path/to/your/img',
    text: 'the text you want',
    href: 'url' (not required)
  },
  {
    ...
  }
]
```
each object of the array corresponds to a cell of the custom table




