### PR TITLE
[Algolia] Disable legacy search

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -281,18 +281,6 @@ module.exports = {
     'tabs',
     require('./meta-tags-plugin/index.js'),
     [require('./page-attributes/index.js'), { sections }],
-    process.env.ALGOLIA_WRITE_KEY && !process.env.DISABLE_ALGOLIA
-      ? [
-        require('./index-to-algolia/index.js'),
-        {
-          algoliaAppId: process.env.ALGOLIA_APP_ID || algoliaDefaultAppId,
-          algoliaWriteKey: process.env.ALGOLIA_WRITE_KEY,
-          algoliaIndex: process.env.ALGOLIA_INDEX || algoliaDefaultIndex,
-          clearIndex: process.env.ALGOLIA_CLEAR_INDEX,
-          repoName: process.env.REPO_NAME
-        }
-      ]
-      : {},
     [
       require('vuepress-frontmatter-lint'),
       {

--- a/src/.vuepress/index-to-algolia/index.js
+++ b/src/.vuepress/index-to-algolia/index.js
@@ -8,6 +8,10 @@ const { findRootNode, getParentNode } = require('./util.js');
 const records = [];
 const ALGOLIA_MAX_CONTENT_LENGTH = 8500;
 
+/**
+ * THIS PLUGIN IS OBSOLETE - We now use Algolia DOCSEARCH
+ * service for Open Source projects.
+ */
 module.exports = (options, ctx) => ({
   name: 'index-to-algolia',
 


### PR DESCRIPTION
We now use Algolia DOCSEARCH, so we don't need to use the former search index anymore.