### PR TITLE
[docsearch] using docs index on our app

### DIFF
--- a/src/.vuepress/theme/Search.vue
+++ b/src/.vuepress/theme/Search.vue
@@ -44,14 +44,6 @@ export default {
       return getCurrentVersion(this.$page);
     },
   },
-  watch: {
-    $lang(newValue) {
-      this.update(this.options, newValue);
-    },
-    options(newValue) {
-      this.update(newValue, this.$lang);
-    },
-  },
   mounted() {
     this.initialize(this.options, this.$lang);
     this.placeholder = this.$site.themeConfig.searchPlaceholder || '';

--- a/src/.vuepress/theme/Search.vue
+++ b/src/.vuepress/theme/Search.vue
@@ -29,6 +29,8 @@
 </template>
 
 <script>
+import { getCurrentVersion } from '../helpers';
+
 export default {
   name: 'AlgoliaSearchBox',
   props: ['options'],
@@ -36,6 +38,11 @@ export default {
     return {
       placeholder: undefined,
     };
+  },
+  computed: {
+    kuzzleMajor() {
+      return getCurrentVersion(this.$page);
+    },
   },
   watch: {
     $lang(newValue) {
@@ -62,8 +69,19 @@ export default {
         docsearch = docsearch.default;
         docsearch({
           inputSelector: '#algolia-search-input',
-          apiKey: 'c6452010dc26eb671d637214f1110c91',
-          indexName: 'kuzzle',
+
+          // KUZZLEIO APP
+          apiKey: 'de63216cd8d0116b2755916b9a38ae35',
+          indexName: 'docs',
+          appId: 'VF5HP4ZVDU',
+
+          // DOCSEARCH APP
+          // apiKey: 'c6452010dc26eb671d637214f1110c91',
+          // indexName: 'kuzzle',
+
+          algoliaOptions: {
+            facetFilters: [`version:${this.kuzzleMajor}`],
+          },
         });
       });
     },


### PR DESCRIPTION
Use Algolia DOCSEARCH against the `docs` index in our private app. The searches are performed using the facet filter on the current Kuzzle major version.

### How should this be manually tested?

- Go to a V2 page
- search `mGet` (or something similar)
- verify that the results are all pertinent to the v2
- Go to a v1 page and try the same thing.