### PR TITLE
[Algolia] Hitting production search index

### DIFF
--- a/src/.vuepress/theme/Search.vue
+++ b/src/.vuepress/theme/Search.vue
@@ -62,14 +62,9 @@ export default {
         docsearch({
           inputSelector: '#algolia-search-input',
 
-          // KUZZLEIO APP
-          apiKey: 'de63216cd8d0116b2755916b9a38ae35',
-          indexName: 'docs',
-          appId: 'VF5HP4ZVDU',
-
           // DOCSEARCH APP
-          // apiKey: 'c6452010dc26eb671d637214f1110c91',
-          // indexName: 'kuzzle',
+          apiKey: 'c6452010dc26eb671d637214f1110c91',
+          indexName: 'kuzzle',
 
           algoliaOptions: {
             facetFilters: [`version:${this.kuzzleMajor}`],


### PR DESCRIPTION
Just a little PR to make everybody aware that, from now on, search on next-docs is going to hit the production search index. Search results will then redirect to docs.kuzzle.io