### PR TITLE
Remove dropdown list item icons

### DIFF
--- a/src/.vuepress/components/MenuDropdown.vue
+++ b/src/.vuepress/components/MenuDropdown.vue
@@ -10,7 +10,6 @@
     ></span>
     <ul class="MenuDropdown-list" :class="{ visible: isListVisible }">
       <li v-for="item in items" class="MenuDropdown-list-item" :key="item.name">
-        <i class="fa fa-caret-right"></i>
         <a
           class="MenuDropdown-list-item-link"
           :href="item.url"

--- a/src/.vuepress/theme/styles/extensions/_menuDropdown.scss
+++ b/src/.vuepress/theme/styles/extensions/_menuDropdown.scss
@@ -31,12 +31,6 @@
   &-list-item {
     line-height: 2.2em;
     font-size: 0.9em;
-
-    i {
-      font-size: 11px;
-      margin-right: 5px;
-      opacity: 0.9;
-    }
   }
 
   &-list-item-link {


### PR DESCRIPTION
## What does this PR do?
Removal of dropdown item icons that did not match the UX from the documentation

![image](https://user-images.githubusercontent.com/3192870/101642456-55133f80-3a33-11eb-810d-ec67a9211f5d.png)

