### PR TITLE
Fix scroll to anchor on chrome

### DIFF
--- a/src/.vuepress/theme/Layout.vue
+++ b/src/.vuepress/theme/Layout.vue
@@ -217,6 +217,14 @@ export default {
     }
   },
   mounted() {
+    // fix scroll to anchor on chrome https://github.com/vuejs/vuepress/issues/2558
+    if (location.hash && location.hash !== '#') {
+      const anchorLocation = decodeURIComponent(location.hash);
+      const anchorElement = document.querySelector(anchorLocation);
+      if (anchorElement && anchorElement.offsetTop)
+        window.scrollTo(0, anchorElement.offsetTop);
+    }
+
     document.onreadystatechange = () => {
       if (document.readyState === 'complete') {
         this.isLoading = false;


### PR DESCRIPTION
## What does this PR do?
Fix #507 
Add `window.scrollTo()` on layout mounted hook if an anchor is detected on the url
