### PR TITLE
Fix SDK Go V3 documentation not deployed

### DIFF
--- a/src/.vuepress/sections.json
+++ b/src/.vuepress/sections.json
@@ -137,13 +137,13 @@
     "released": true
   },
   "/sdk/go/3/": {
-    "kuzzleMajor": 3,
+    "kuzzleMajor": 2,
     "section": "sdk",
     "subsection": "go",
     "name": "Golang",
     "version": 3,
     "icon": "/logos/go.svg",
-    "released": true
+    "released": false
   },
   "/sdk/java/1/": {
     "kuzzleMajor": 1,


### PR DESCRIPTION
This PR is meant to fix the doc of `SDK Go V3` not being shown on `docs.kuzzle.io`, so first we will test it on `next-docs.kuzzle.io`, then I will do another PR if everything is good to deploy the documentation of the SDK Go on `docs.kuzzle.io`

fix [#284](https://github.com/orgs/kuzzleio/projects/1#card-51428807)