### PR TITLE
[HOTFIX] remove unreleased SDK from SDK-selector list

### DIFF
--- a/src/.vuepress/theme/Layout.vue
+++ b/src/.vuepress/theme/Layout.vue
@@ -110,7 +110,8 @@ export default {
       return this.$page.sectionList.filter(
         s =>
           s.kuzzleMajor === this.kuzzleMajor &&
-          (s.section === 'sdk' || s.subsection === 'api')
+          (s.section === 'sdk' || s.subsection === 'api') &&
+          s.released
       );
     },
     showDeprecatedBanner() {


### PR DESCRIPTION
## What does this PR do?
Remove unreleased SDK from SDK-selector list

### How should this be manually tested?

  - Step 1 : `kuzdoc iterate-repos:install --repositories=kuzzle-2 `
  - Step 2 : `npm run dev`
  - Step 3 :  go to http://localhost:8080/core/2/api/
  - Step 4 :  check the SDK selector, the SDK-GO v3 should no longer be present 
