### PR TITLE
Fix wrong Dart SDK version

### DIFF
--- a/src/.vuepress/sections.json
+++ b/src/.vuepress/sections.json
@@ -216,7 +216,7 @@
     "section": "sdk",
     "subsection": "dart",
     "name": "Dart",
-    "version": 1,
+    "version": 2,
     "icon": "/logos/dart.svg",
     "released": true
   },


### PR DESCRIPTION
## What does this PR do?
Fix wrong Dart-SDK version from 1.x to 2.x in `sections.json`
 
### How should this be manually tested?

  - Step 1 : `$ npm run dev`
  - Step 2 : go to http://localhost:8080/sdk/v2.html
  - Step 3 :  Dart-sdk version should be `2.x`
