### PR TITLE
add version deprecation banner

### DIFF
--- a/src/.vuepress/components/MajorVersionDeprecation.vue
+++ b/src/.vuepress/components/MajorVersionDeprecation.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="alert alert-warning deprecatedBanner">
+    <p>
+      You are currently looking at the documentation of a previous version of
+      Kuzzle. We strongly recommend that you use the
+      <a :href="`/v${kuzzleLatestMajor}`">latest version</a>.
+      You can also use the version selector in the top menu.
+    </p>
+  </div>
+</template>
+
+<script>
+import { DEFAULT_VERSION } from "../helpers";
+
+export default {
+  computed: {
+    kuzzleLatestMajor() {
+      return DEFAULT_VERSION;
+    },
+  },
+};
+</script>

--- a/src/.vuepress/theme/Layout.vue
+++ b/src/.vuepress/theme/Layout.vue
@@ -43,6 +43,7 @@
           <!-- Content -->
 
           <div class="md-content">
+            <major-version-deprecation v-if="kuzzleMajor !== kuzzleLatestMajor" />
             <div v-if="showDeprecatedBanner">
               <component
                 v-if="deprecatedBannerComponent"
@@ -69,7 +70,8 @@ import DeprecatedBanner from '../components/DeprecatedBanner.vue';
 import Sidebar from './Sidebar.vue';
 import TOC from './TOC.vue';
 import Footer from './Footer.vue';
-import { getCurrentVersion } from '../helpers';
+import { getCurrentVersion, DEFAULT_VERSION } from '../helpers';
+import MajorVersionDeprecation from '../components/MajorVersionDeprecation.vue';
 
 const {
   getFirstValidChild,
@@ -83,7 +85,8 @@ export default {
     Sidebar,
     TOC,
     DeprecatedBanner,
-    Footer
+    Footer,
+    MajorVersionDeprecation
   },
   data() {
     return {
@@ -92,6 +95,9 @@ export default {
     };
   },
   computed: {
+    kuzzleLatestMajor() {
+      return DEFAULT_VERSION;
+    },
     kuzzleMajor() {
       return getCurrentVersion(this.$page, null);
     },


### PR DESCRIPTION
The following banner will be added at the top of the content on every page of the documentation when the current major version selected isn't the latest (sdk, api, guides, how to.....). 
The `latest version` link to the `DEFAULT_VERSION` of the documentation, which should always be the latest

![image](https://user-images.githubusercontent.com/44427849/113870522-368b3e00-97b2-11eb-9453-1ce58e1c5259.png)
