### PR TITLE
Add "robot:noindex" meta in the pages of the old versions of Kuzzle

### DIFF
--- a/src/.vuepress/meta-tags-plugin/mixin.js
+++ b/src/.vuepress/meta-tags-plugin/mixin.js
@@ -1,3 +1,5 @@
+import { DEFAULT_VERSION } from '../helpers'
+
 export default {
   mounted() {
     const head = document.head;
@@ -12,6 +14,16 @@ export default {
       metaSection.setAttribute('property', 'article:section');
       metaSection.setAttribute('content', this.$page.currentSection.name);
       head.appendChild(metaSection);
+      
+      if (this.$page.currentSection.kuzzleMajor < DEFAULT_VERSION) {
+        const metaNoIndex = document.createElement('meta');
+        metaNoIndex.setAttribute('property', 'robot');
+        metaNoIndex.setAttribute('content', 'noindex');
+        head.appendChild(metaNoIndex);
+      }
     }
+
+    
+
   }
 };

--- a/src/.vuepress/meta-tags-plugin/mixin.js
+++ b/src/.vuepress/meta-tags-plugin/mixin.js
@@ -22,8 +22,5 @@ export default {
         head.appendChild(metaNoIndex);
       }
     }
-
-    
-
   }
 };


### PR DESCRIPTION
## What does this PR do?
Add `robot:noindex` meta in the pages of the old versions of Kuzzle.

### How should this be manually tested?
* `kuzdoc iterate-repos:install --repositories=kuzzle-1,kuzzle-2`
* `npm run dev`
* check meta in `<head>` tag for some kuzzle v1 and kuzzle v2 pages

