### PR TITLE
Better Open Graph meta tags

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 
 const siteDescription =
-  'Check out the complete Kuzzle documentation: Guides, framework, API, SDKs and officials plugins';
+  'Check out the complete Kuzzle Documentation: Guides, Framework, API, SDKs and officials plugins';
 const siteTitle = 'Kuzzle Documentation';
 const versionString = require('./getVersionString');
 const base = process.env.SITE_BASE || '/';

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,5 +1,7 @@
 const webpack = require('webpack');
 
+const siteDescription =
+  'Check out the complete Kuzzle documentation: Guides, framework, API, SDKs and officials plugins';
 const siteTitle = 'Kuzzle Documentation';
 const versionString = require('./getVersionString');
 const base = process.env.SITE_BASE || '/';
@@ -11,6 +13,7 @@ const sections = require('./sections.json');
 
 module.exports = {
   title: siteTitle,
+  description: siteDescription,
   base,
   shouldPrefetch: () => false,
   head: [
@@ -54,18 +57,20 @@ module.exports = {
       'meta',
       {
         name: 'twitter:image',
-        content: '/favicon/favicon-196x196.png'
+        content: `${base}favicon/favicon-196x196.png`
       }
     ],
 
     // -- Open Graph data
     ['meta', { property: 'og:type', content: 'article' }],
     ['meta', { property: 'og:site_name', content: siteTitle }],
+    ['meta', { property: 'og:image:width', content: '96' }],
+    ['meta', { property: 'og:image:height', content: '96' }],
     [
       'meta',
       {
         property: 'og:image',
-        content: '/favicon/favicon-96x96.png'
+        content: `${base}favicon/favicon-96x96.png`
       }
     ],
     // The following two fields don't seem to be meaningful

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,18 +1,16 @@
 const webpack = require('webpack');
 
-const siteTitle = 'Kuzzle Docs';
-const siteDescription = 'Kuzzle Documentation';
+const siteTitle = 'Kuzzle Documentation';
 const versionString = require('./getVersionString');
 const base = process.env.SITE_BASE || '/';
 const algoliaDefaultAppId = 'VF5HP4ZVDU';
 const algoliaDefaultIndex = 'documentation-dev';
 const algoliaDefaultSearchKey = 'de63216cd8d0116b2755916b9a38ae35';
 const googleAnalyticsID = 'UA-67035328-7';
-const sections = require('./sections.json')
+const sections = require('./sections.json');
 
 module.exports = {
   title: siteTitle,
-  description: siteDescription,
   base,
   shouldPrefetch: () => false,
   head: [
@@ -56,19 +54,18 @@ module.exports = {
       'meta',
       {
         name: 'twitter:image',
-        content: '/favicon-196x196.png'
+        content: '/favicon/favicon-196x196.png'
       }
     ],
 
     // -- Open Graph data
-    ['meta', { property: 'og:title', content: siteTitle }],
     ['meta', { property: 'og:type', content: 'article' }],
     ['meta', { property: 'og:site_name', content: siteTitle }],
     [
       'meta',
       {
         property: 'og:image',
-        content: 'favicon/favicon-96x96.png'
+        content: '/favicon/favicon-96x96.png'
       }
     ],
     // The following two fields don't seem to be meaningful
@@ -275,8 +272,7 @@ module.exports = {
         REPO_SLUG:
           JSON.stringify(process.env.TRAVIS_REPO_SLUG) ||
           JSON.stringify('kuzzleio/documentation'),
-        BRANCH:
-          JSON.stringify(process.env.TRAVIS_BRANCH)
+        BRANCH: JSON.stringify(process.env.TRAVIS_BRANCH)
       })
     ]
   },

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 
 const siteDescription =
-  'Check out the complete Kuzzle Documentation: Guides, Framework, API, SDKs and officials plugins';
+  'Complete Kuzzle Documentation: Guides, Framework, API, SDKs and officials plugins';
 const siteTitle = 'Kuzzle Documentation';
 const versionString = require('./getVersionString');
 const base = process.env.SITE_BASE || '/';

--- a/src/.vuepress/helpers.js
+++ b/src/.vuepress/helpers.js
@@ -1,5 +1,5 @@
 export const VERSION_QUERY_KEY = 'version';
-export const DEFAULT_VERSION = 2
+export const DEFAULT_VERSION = 2;
 
 export const getCurrentVersion = (page, state) => {
   if (!page.currentSection) {
@@ -11,4 +11,11 @@ export const getCurrentVersion = (page, state) => {
   }
 
   return page.currentSection.kuzzleMajor;
-}
+};
+
+export const createMetaTag = (property, content) => {
+  const meta = document.createElement('meta');
+  meta.setAttribute('property', property);
+  meta.setAttribute('content', content);
+  return meta;
+};

--- a/src/.vuepress/meta-tags-plugin/mixin.js
+++ b/src/.vuepress/meta-tags-plugin/mixin.js
@@ -6,12 +6,13 @@ export default {
 
     head.appendChild(createMetaTag('article:tag', this.$page.title));
     head.appendChild(createMetaTag('og:title', this.$page.title));
-
-    if (this.$page.frontmatter.description) {
-      head.appendChild(
-        createMetaTag('og:description', this.$page.frontmatter.description)
-      );
-    }
+    head.appendChild(createMetaTag('og:url', document.URL));
+    head.appendChild(
+      createMetaTag(
+        'og:description',
+        this.$page.frontmatter.description || this.$site.description
+      )
+    );
 
     if (this.$page.currentSection) {
       head.appendChild(

--- a/src/.vuepress/meta-tags-plugin/mixin.js
+++ b/src/.vuepress/meta-tags-plugin/mixin.js
@@ -1,25 +1,25 @@
-import { DEFAULT_VERSION } from '../helpers'
+import { DEFAULT_VERSION, createMetaTag } from '../helpers';
 
 export default {
   mounted() {
     const head = document.head;
 
-    const metaTitle = document.createElement('meta');
-    metaTitle.setAttribute('property', 'article:tag');
-    metaTitle.setAttribute('content', this.$page.title);
-    head.appendChild(metaTitle);
+    head.appendChild(createMetaTag('article:tag', this.$page.title));
+    head.appendChild(createMetaTag('og:title', this.$page.title));
+
+    if (this.$page.frontmatter.description) {
+      head.appendChild(
+        createMetaTag('og:description', this.$page.frontmatter.description)
+      );
+    }
 
     if (this.$page.currentSection) {
-      const metaSection = document.createElement('meta');
-      metaSection.setAttribute('property', 'article:section');
-      metaSection.setAttribute('content', this.$page.currentSection.name);
-      head.appendChild(metaSection);
-      
+      head.appendChild(
+        createMetaTag('article:section', this.$page.currentSection.name)
+      );
+
       if (this.$page.currentSection.kuzzleMajor < DEFAULT_VERSION) {
-        const metaNoIndex = document.createElement('meta');
-        metaNoIndex.setAttribute('property', 'robot');
-        metaNoIndex.setAttribute('content', 'noindex');
-        head.appendChild(metaNoIndex);
+        head.appendChild(createMetaTag('robot', 'noindex'));
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?
fix [440](https://github.com/kuzzleio/documentation/issues/440) Enhance Open Graph meta tags
```
<meta property="og:type" content="article" />
<meta property="og:site_name" content="Kuzzle Documentation" />
<meta property="og:image:width" content="96" />
<meta property="og:image:height" content="96" />
<meta property="og:image" content="/favicon/favicon-96x96.png" />
<meta property="og:url" content="http://localhost:8080/core/2/guides/introduction/what-is-kuzzle/">
<meta property="og:title" content="What is Kuzzle">
<meta property="og:description" content="Why are we spending so much time developing our backend?">
```
Note that, for the moment we will not generate an image with `vercel/og-image`. Also, to be sure of the rendering, we'll have to check on next-docs and maybe retouch if necessary