### PR TITLE
Fix open sub-menu height

### DIFF
--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -32,7 +32,7 @@
               v-for="item__1 in getPageChildren(root).filter(
                 p => p.frontmatter.type === 'branch'
               )"
-              :key="item__1"
+              :key="item__1.path"
               class="md-nav__item-container"
             >
               <li
@@ -44,7 +44,10 @@
                 {{ item__1.frontmatter.title }}
               </li>
 
-              <div v-for="item__2 in getPageChildren(item__1)" :key="item__2">
+              <div
+                v-for="item__2 in getPageChildren(item__1)"
+                :key="item__2.path"
+              >
                 <li class="md-nav__item md-nav-title">
                   <div
                     class="md-nav__link"
@@ -99,7 +102,7 @@
                 >
                   <div
                     v-for="item__3 of getPageChildren(item__2)"
-                    :key="item__3"
+                    :key="item__3.path"
                     :id="getId([item__1.title, item__2.title, item__3.title])"
                     class="md-nav__item"
                   >

--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -32,6 +32,7 @@
               v-for="item__1 in getPageChildren(root).filter(
                 p => p.frontmatter.type === 'branch'
               )"
+              :key="item__1"
               class="md-nav__item-container"
             >
               <li
@@ -43,7 +44,7 @@
                 {{ item__1.frontmatter.title }}
               </li>
 
-              <div v-for="item__2 in getPageChildren(item__1)">
+              <div v-for="item__2 in getPageChildren(item__1)" :key="item__2">
                 <li class="md-nav__item md-nav-title">
                   <div
                     class="md-nav__link"
@@ -98,8 +99,9 @@
                 >
                   <div
                     v-for="item__3 of getPageChildren(item__2)"
-                    class="md-nav__item"
+                    :key="item__3"
                     :id="getId([item__1.title, item__2.title, item__3.title])"
+                    class="md-nav__item"
                   >
                     <li v-if="$page.path === item__3.path">
                       <router-link
@@ -224,18 +226,9 @@ export default {
       if (!childs) {
         return;
       }
+
       const item2Id = this.getId([item__1.title, item__2.title]);
-      const item3Id = this.getId([
-        item__1.title,
-        item__2.title,
-        childs[0].title
-      ]);
-      if (!document.getElementById(item3Id)) {
-        return;
-      }
-      const childSize = document.getElementById(item3Id).offsetHeight;
-      const menuHeight = `${childs.length * childSize}px`;
-      document.getElementById(item2Id).style.height = menuHeight;
+      document.getElementById(item2Id).style.height = 'auto';
     },
     closeSidebar(item) {
       this.$emit('closeSidebar');

--- a/src/.vuepress/theme/styles/layout/_base.scss
+++ b/src/.vuepress/theme/styles/layout/_base.scss
@@ -73,7 +73,7 @@ hr {
 
 // Template-wide grid
 .md-grid {
-  max-width: 122rem;
+  max-width: 124rem;
   margin-right: auto;
   margin-left: auto;
 }

--- a/src/.vuepress/theme/styles/layout/_content.scss
+++ b/src/.vuepress/theme/styles/layout/_content.scss
@@ -3,25 +3,27 @@
 // ----------------------------------------------------------------------------
 
 // Content container
+$content-margin: 26rem;
+
 .md-content {
   // [tablet landscape +]: Add space for table of contents
   @include break-from-device(tablet landscape) {
-    margin-right: 24.2rem;
+    margin-right: $content-margin;
 
     // Adjust for RTL languages
     [dir='rtl'] & {
       margin-right: initial;
-      margin-left: 24.2rem;
+      margin-left: $content-margin;
     }
   }
 
   // [screen +]: Add space for table of contents
   @include break-from-device(screen) {
-    margin-left: 24.2rem;
+    margin-left: $content-margin;
 
     // Adjust for RTL languages
     [dir='rtl'] & {
-      margin-right: 24.2rem;
+      margin-right: $content-margin;
     }
   }
 

--- a/src/.vuepress/theme/styles/layout/_sidebar.scss
+++ b/src/.vuepress/theme/styles/layout/_sidebar.scss
@@ -12,7 +12,7 @@ $md-toggle__drawer--checked: '[data-md-toggle="drawer"]:checked ~ .md-container'
 // Sidebar container
 .md-sidebar {
   position: fixed;
-  width: 23.2rem;
+  width: 25rem;
   padding: 2.4rem 0;
   overflow: hidden;
 
@@ -94,12 +94,13 @@ $md-toggle__drawer--checked: '[data-md-toggle="drawer"]:checked ~ .md-container'
     }
 
     // [screen +]: Limit to grid
+    $nav-sidebar-margin: 125rem;
     @include break-from-device(screen) {
-      margin-left: 122rem;
+      margin-left: $nav-sidebar-margin;
 
       // Adjust for RTL languages
       [dir='rtl'] & {
-        margin-right: 122rem;
+        margin-right: $nav-sidebar-margin;
         margin-left: initial;
       }
     }


### PR DESCRIPTION
## What does this PR do?
Fix #523
Set the height of open sub-menu to `auto` instead of calculating the height of children

### Other changes
Enlarged left sidebar and layout to avoid line breaks on menu items with long names
before:
![image](https://user-images.githubusercontent.com/3192870/120998321-490cfe00-c788-11eb-97dc-dee5f21670fb.png)

after:
![image](https://user-images.githubusercontent.com/3192870/120998203-27ac1200-c788-11eb-9592-ec91706caa1e.png)

### Boyscout
fix Vue missing `v-bind:key` warnings