### PR TITLE
Add JS doc generator

### DIFF
--- a/generator/javascript/ClassExtractor.ts
+++ b/generator/javascript/ClassExtractor.ts
@@ -1,0 +1,125 @@
+import { EventEmitter } from 'stream';
+
+import { ClassDeclaration, JSDoc, Project, SyntaxKind } from 'ts-morph';
+
+export type InfoMethod = {
+  name: string;
+  signature: string;
+  description: string;
+  args: InfoMethodArgs[];
+  internal: boolean;
+  returnType: string;
+  returnTypeRaw: string;
+  scope: 'public' | 'private' | 'protected';
+}
+
+export type InfoMethodArgs = {
+  name: string;
+  description: string;
+  type: string;
+  typeRaw: string;
+  optional: boolean;
+}
+
+export type InfoClass = {
+  name: string;
+  description: string;
+  internal: boolean;
+  methods: InfoMethod[];
+}
+
+export class ClassExtractor extends EventEmitter {
+  private filePath: string;
+
+  public info: InfoClass;
+
+  public methods: InfoMethod[] = [];
+
+  constructor (filePath: string,) {
+    super();
+
+    this.filePath = filePath;
+  }
+
+  extract () {
+    const project = new Project();
+
+    for (const classDeclaration of project.addSourceFileAtPath(this.filePath).getClasses()) {
+      this.extractClass(classDeclaration);
+    }
+  }
+
+  private extractClass (classDeclaration: ClassDeclaration) {
+    const name = classDeclaration.getName();
+
+    const jsDoc = classDeclaration.getChildrenOfKind(SyntaxKind.JSDocComment)[0];
+
+    const description = this.formatText(jsDoc.getComment());
+
+    const internal =  Boolean(jsDoc.getTags().find(tag => tag.getTagName() === 'internal'));
+
+    const methods = this.extractMethods(classDeclaration);
+
+    this.info = { name, description, internal, methods };
+
+    this.emit('class', this.info);
+  }
+
+  private extractMethods (classDeclaration: ClassDeclaration): InfoMethod[] {
+    const methods: InfoMethod[] = [];
+
+    for (const method of classDeclaration.getMethods()) {
+      const jsDoc = method.getChildrenOfKind(SyntaxKind.JSDocComment)[0];
+
+      if (! jsDoc) {
+        continue;
+      }
+
+      const name = method.getName();
+
+      const description = this.formatText(jsDoc.getComment());
+
+      const args = this.getMethodArgs(jsDoc);
+
+      const internal = Boolean(jsDoc.getTags().find(tag => tag.getTagName() === 'internal'));
+
+      const scope = method.getScope();
+
+      const returnTypeRaw = method.getReturnType().getText();
+      const returnType = returnTypeRaw.replace(/import\(.*\)\./, '');
+      const signature = `${scope === 'public' ? '' : `${scope} `}${name} (${args.map(arg => `${arg.name}${arg.optional ? '?' : ''}: ${arg.type}`).join(', ')}): ${returnType}`;
+
+      const methodInfo = { name, signature, description, args, internal, scope, returnType, returnTypeRaw };
+
+      methods.push(methodInfo);
+    }
+
+    return methods;
+  }
+
+  private getMethodArgs (jsDoc: JSDoc): InfoMethodArgs[] {
+    const args: InfoMethodArgs[] = jsDoc.getTags()
+      .filter(tag => tag.getTagName() === 'param')
+      .map(tag => {
+        const typeRaw = tag.getSymbol().getValueDeclaration().getType().getText();
+        const type = typeRaw.replace(/import\(.*\)\./, '');
+
+        return {
+          name: tag.getSymbol().getEscapedName(),
+          description: this.formatText(tag.getComment()),
+          type,
+          typeRaw,
+          // If someone find better than this ugly hack I'm in!
+          optional: Boolean(
+               tag.getSymbol().getValueDeclaration()['_compilerNode']['questionToken']
+            || tag.getSymbol().getValueDeclaration()['_compilerNode']['initalizer']),
+        };
+      });
+
+    return args;
+  }
+
+  private formatText (text: any) {
+    return text.replace('\n\n', '\n') as string;
+  }
+}

--- a/generator/javascript/MarkdownFormatter.ts
+++ b/generator/javascript/MarkdownFormatter.ts
@@ -1,0 +1,95 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
+
+import _ from 'lodash';
+
+import { InfoClass, InfoMethod } from './ClassExtractor';
+
+function upFirst (string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function kebabCase(string: string): string {
+  return string
+    // get all lowercase letters that are near to uppercase ones
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    // replace all spaces and low dash
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+function contextualizeKeys (context: string, values: Record<string, any>) {
+  const obj: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    obj[`${context}${upFirst(key)}`] = value;
+  }
+
+  return obj;
+}
+
+export class MarkdownFormatter {
+  private outputDir: string;
+  private templateDir: string;
+  private baseDir: string;
+
+  constructor (outputDir: string, templateDir: string) {
+    this.outputDir = outputDir;
+    this.templateDir = templateDir;
+  }
+
+  onClass (classInfo: InfoClass) {
+    if (classInfo.internal) {
+      return;
+    }
+
+    this.baseDir = path.join(this.outputDir, kebabCase(classInfo.name));
+
+    const rootIndex = this.renderTemplate(
+      ['class', 'index.tpl.md'],
+      contextualizeKeys('class', classInfo));
+
+    this.writeFile(['index.md'], rootIndex);
+
+    const introduction = this.renderTemplate(
+      ['class', 'introduction', 'index.tpl.md'],
+      contextualizeKeys('class', classInfo));
+
+    this.writeFile(['introduction', 'index.md'], introduction);
+
+    for (const method of classInfo.methods) {
+      this.onMethod(classInfo, method);
+    }
+  }
+
+  onMethod (classInfo: InfoClass, infoMethod: InfoMethod) {
+    if (infoMethod.internal) {
+      return;
+    }
+
+    const method = this.renderTemplate(
+      ['class', 'method', 'index.tpl.md'],
+      {
+        ...contextualizeKeys('method', infoMethod),
+        ...contextualizeKeys('class', classInfo),
+      });
+
+    this.writeFile([infoMethod.name, 'index.md'], method);
+  }
+
+  private writeFile (paths: string[], content: string) {
+    const fullPath = path.join(this.baseDir, ...paths.map(p => kebabCase(p)));
+
+    mkdirSync(path.dirname(fullPath), { recursive: true });
+
+    writeFileSync(fullPath, content);
+  }
+
+  private renderTemplate (paths: string[], values: Record<string, any> = {}): string {
+    const fullPath = path.join(this.templateDir, ...paths);
+
+    const compiled = _.template(readFileSync(fullPath, { encoding: 'utf-8' }));
+
+    return compiled(values);
+  }
+}

--- a/generator/javascript/README.md
+++ b/generator/javascript/README.md
@@ -1,0 +1,9 @@
+## Doc Generator
+
+This allows to generate documentation of core-classes from the Typescript definition.
+
+```bash
+cd doc/generator
+
+node generate.js ../../src/core/Observer.ts Observer ./out
+```

--- a/generator/javascript/generate.js
+++ b/generator/javascript/generate.js
@@ -1,0 +1,24 @@
+require('ts-node/register')
+
+/* Script Arguments ==================================================== */
+
+const filePath = process.argv[2];
+const outDir = process.argv[3];
+
+if (! filePath || ! outDir) {
+  console.log(`Usage: node ${process.argv[1]} <file path> <out dir>`);
+}
+
+/* ===================================================================== */
+
+const { ClassExtractor } = require('./ClassExtractor');
+const { MarkdownFormatter } = require('./MarkdownFormatter');
+
+const formatter = new MarkdownFormatter(outDir, './templates');
+const extractor = new ClassExtractor(filePath);
+
+extractor.on('class', (info) => {
+  formatter.onClass(info);
+});
+
+extractor.extract();

--- a/generator/javascript/templates/class/index.tpl.md
+++ b/generator/javascript/templates/class/index.tpl.md
@@ -1,0 +1,6 @@
+---
+code: true
+type: branch
+title: <%= className %>
+description: <%= className %> class documentation
+---

--- a/generator/javascript/templates/class/introduction/index.tpl.md
+++ b/generator/javascript/templates/class/introduction/index.tpl.md
@@ -1,0 +1,13 @@
+---
+code: false
+type: page
+title: Introduction
+description: <%= className %> class
+order: 0
+---
+
+# <%= className %>
+
+<SinceBadge version="auto-version" />
+
+<%= classDescription %>

--- a/generator/javascript/templates/class/method/index.tpl.md
+++ b/generator/javascript/templates/class/method/index.tpl.md
@@ -1,0 +1,23 @@
+---
+code: true
+type: page
+title: <%= methodName %>
+description: <%= className %> <%= methodName %> method
+---
+
+# <%= methodName %>
+
+<SinceBadge version="auto-version" />
+
+<%= methodDescription %>
+
+## Arguments
+
+```js
+<%= methodSignature %>
+```
+
+| Argument | Type | Description |
+|----------|------|-------------|
+<% _.forEach(methodArgs, function(arg) { %>| `<%= arg.name %>` | <pre><%= arg.type %></pre> | <%= arg.description %> |
+<% }); %>

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash": "^4.17.11",
     "mocha": "^6.1.4",
     "mock-require": "^3.0.3",
+    "ts-morph": "^13.0.2",
     "should": "^13.2.3",
     "should-sinon": "0.0.6",
     "sinon": "^7.3.2",


### PR DESCRIPTION
## What does this PR do?

This allows to generate documentation of core-classes from the Typescript definition.

```bash
cd generator/javascript

// node generate.js <file path> <class name> <destination dir>
node generate.js ../../src/core/Observer.ts Observer ./out
```