### PR TITLE
Adding new metadata keywords and refactoring title / descriptions to be more precise + alt on images

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 
 const siteDescription =
   'Complete Kuzzle Documentation: Guides, Framework, API, SDKs and officials plugins';
-const siteTitle = 'Kuzzle Documentation';
+const siteTitle = '| Kuzzle Documentation V2';
 const versionString = require('./getVersionString');
 const base = process.env.SITE_BASE || '/';
 const algoliaDefaultAppId = 'VF5HP4ZVDU';
@@ -67,7 +67,8 @@ module.exports = {
       'meta',
       {
         property: 'twitter:image',
-        content: 'https://docs.kuzzle.io/og-image.png'
+        content: 'https://docs.kuzzle.io/og-image.png',
+        alt: "kuzzle logo"
       }
     ],
 
@@ -325,6 +326,10 @@ module.exports = {
           code: {
             type: Boolean,
             required: true
+          },
+          meta:{
+            type: Array,
+          
           }
         },
         exclude: [

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -2,8 +2,8 @@ const webpack = require('webpack');
 
 const siteDescription =
   'Complete Kuzzle Documentation: Guides, Framework, API, SDKs and officials plugins';
-const siteTitle = '| Kuzzle Documentation V2';
 const versionString = require('./getVersionString');
+const siteTitle = `| Kuzzle Documentation ${versionString}`;
 const base = process.env.SITE_BASE || '/';
 const algoliaDefaultAppId = 'VF5HP4ZVDU';
 const algoliaDefaultIndex = 'documentation-dev';

--- a/src/.vuepress/theme/Footer.vue
+++ b/src/.vuepress/theme/Footer.vue
@@ -7,6 +7,7 @@
           <img
             class="md-footer-external__link__img"
             src="/logos/logo-github.svg"
+            alt="github logo"
           />
           <div class="md-footer-external__link__title">Github</div>
           <div class="md-footer-external__link__description">
@@ -22,6 +23,7 @@
           <img
             class="md-footer-external__link__img"
             src="/logos/logo-stack-overflow.svg"
+            alt="stack-overflow logo"
           />
           <div class="md-footer-external__link__title">Stack Overflow</div>
           <div class="md-footer-external__link__description">
@@ -34,6 +36,7 @@
           <img
             class="md-footer-external__link__img"
             src="/logos/logo-discord.svg"
+            alt="discord logo"
           />
           <div class="md-footer-external__link__title">Discord</div>
           <div class="md-footer-external__link__description">
@@ -45,6 +48,7 @@
         <a
           href="https://www.youtube.com/channel/UCHcEzVQoH10YSyxc7jD3SMw"
           target="_blank"
+          alt="youtube logo"
         >
           <img
             class="md-footer-external__link__img"

--- a/src/.vuepress/theme/Header.vue
+++ b/src/.vuepress/theme/Header.vue
@@ -15,7 +15,7 @@
           <!-- Link to home -->
           <div class="md-flex__cell md-flex__cell--shrink">
             <a href="/" class="md-header-nav__button md-logo">
-              <img src="/logo-min.png" width="40" height="40" />
+              <img src="/logo-min.png" alt= "kuzzle logo mini" width="40" height="40" />
             </a>
           </div>
           <!-- Button to toggle drawer -->

--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -12,7 +12,7 @@
             for="drawer"
           >
             <span class="md-nav__button md-logo">
-              <img src="/logo-min.png" width="48" height="48" />
+              <img src="/logo-min.png" alt="kuzzle logo mini" width="48" height="48" />
             </span>
             <MajorVersionSelector :kuzzle-major="kuzzleMajor" />
           </label>

--- a/src/how-to/index.md
+++ b/src/how-to/index.md
@@ -2,7 +2,12 @@
 code: false
 type: root
 order: 3
-title: How to
+title: Kuzzle How to guides and tutorials 
+meta:
+  - name: description
+    content: Here you can find all the Kuzzle how-to divided into different categories
+  - name: keywords
+    content: Kuzzle, how to, official, guides, tutorials, monitor iot data, iot backend, keep warm data, massive data import, sync to other db, replicate to postgres, iot
 ---
 
 <Redirect to="v2" />

--- a/src/how-to/v2.md
+++ b/src/how-to/v2.md
@@ -2,7 +2,12 @@
 code: false
 type: root
 order: 3
-title: How to
+title: Kuzzle How to guides and tutorials 
+meta:
+  - name: description
+    content: Here you can find all the Kuzzle how-to divided into different categories
+  - name: keywords
+    content: Kuzzle, how to, official, guides, tutorials, monitor iot data, iot backend, keep warm data, massive data import, sync to other db, replicate to postgres, iot
 ---
 
 # Kuzzle How to

--- a/src/index.md
+++ b/src/index.md
@@ -2,8 +2,12 @@
 code: false
 type: page
 order: 0
-title: Kuzzle Documentation
-description: Kuzzle Documentation
+title: Kuzzle documentation 
+meta:
+  - name: description
+    content: Kuzzle V2 official documentation
+  - name: keywords
+    content: Kuzzle, documentation, kuzzle documentation V2, kuzzle V2, what is kuzzle, kuzzle v2 guide, kuzzle v2 tutorial
 ---
 
 <Redirect to="v2" />

--- a/src/official-plugins/index.md
+++ b/src/official-plugins/index.md
@@ -2,7 +2,12 @@
 code: false
 type: root
 order: 3
-title: Official Plugins
+title: Official Kuzzle Plugins
+meta:
+  - name: description
+    content: You can find here a list of officially released kuzzle plugins
+  - name: keywords
+    content: Kuzzle, plugins, official
 ---
 
 <Redirect to="v2" />

--- a/src/official-plugins/v2.md
+++ b/src/official-plugins/v2.md
@@ -2,7 +2,7 @@
 code: false
 type: root
 order: 3
-title: Official Kuzzle Plugins
+title: Kuzzle Official Plugins
 meta:
   - name: description
     content: You can find here a list of officially released kuzzle plugins

--- a/src/official-plugins/v2.md
+++ b/src/official-plugins/v2.md
@@ -2,7 +2,12 @@
 code: false
 type: root
 order: 3
-title: Official Plugins
+title: Official Kuzzle Plugins
+meta:
+  - name: description
+    content: You can find here a list of officially released kuzzle plugins
+  - name: keywords
+    content: Kuzzle, plugins, official
 ---
 
 # Official Plugins

--- a/src/sdk/index.md
+++ b/src/sdk/index.md
@@ -2,7 +2,7 @@
 code: false
 type: root
 order: 3
-title: Kuzzle official SDKs reference
+title: Kuzzle official SDKs references
 meta:
   - name: description
     content: You can find here a list of the officially supported SDK

--- a/src/sdk/index.md
+++ b/src/sdk/index.md
@@ -2,7 +2,12 @@
 code: false
 type: root
 order: 3
-title: SDKs
+title: Kuzzle official SDKs reference
+meta:
+  - name: description
+    content: You can find here a list of the officially supported SDK
+  - name: keywords
+    content: Kuzzle, sdk, official, JS, Javascript, Golang, C#, Dart, Dart Null Safety, Jvm, Java
 ---
 
 <Redirect to="v2" />

--- a/src/sdk/v2.md
+++ b/src/sdk/v2.md
@@ -2,7 +2,7 @@
 code: false
 type: root
 order: 3
-title: Kuzzle official SDKs reference
+title: Kuzzle official SDKs references
 meta:
   - name: description
     content: You can find here a list of the officially supported SDK

--- a/src/sdk/v2.md
+++ b/src/sdk/v2.md
@@ -2,7 +2,12 @@
 code: false
 type: root
 order: 3
-title: SDKs
+title: Kuzzle official SDKs reference
+meta:
+  - name: description
+    content: You can find here a list of the officially supported SDK
+  - name: keywords
+    content: Kuzzle, sdk, official, JS, Javascript, Golang, C#, Dart, Dart Null Safety, Jvm, Java
 ---
 
 # SDKs Reference

--- a/src/v2.md
+++ b/src/v2.md
@@ -2,8 +2,12 @@
 code: false
 type: page
 order: 0
-title: Kuzzle Documentation
-description: Kuzzle Documentation
+title: What is kuzzle | Introduction 
+meta:
+  - name: description
+    content: Kuzzle V2 official documentation
+  - name: keywords
+    content: Kuzzle, documentation, kuzzle documentation V2, kuzzle V2, what is kuzzle, kuzzle v2 guide, kuzzle v2 tutorial
 ---
 
 <RedirectBis to="core/2/guides/introduction/what-is-kuzzle/" />


### PR DESCRIPTION

## Adding new metadata keywords and refactoring title / descriptions to be more precise. Also adding alt to images 

Adding this to most of the index.md and v2.md with this type of header exemple : 

---
title: Kuzzle How to guides and tutorials 
meta:
  - name: description
    content: Here you can find all the Kuzzle how-to divided into different categories
  - name: keywords
    content: Kuzzle, how to, official, guides, tutorials, monitor iot data, iot backend, keep warm data, massive data import, sync to other db, replicate to postgres, iot
---

### How should this be manually tested?


  - Step 1 : check the new metas on the website using the firefox extensions
  - Step 2 : try searching in google (might not update instantly )
  ...

