### PR TITLE
Fix doc : title in the sidebar fix 

### DIFF
--- a/src/.vuepress/theme/Sidebar.vue
+++ b/src/.vuepress/theme/Sidebar.vue
@@ -41,7 +41,7 @@
                   $page.path.startsWith(item__1.path) ? '2' : ''
                 "
               >
-                {{ item__1.frontmatter.title }}
+                {{ item__1.frontmatter.title.split("|")[0] }}
               </li>
 
               <div
@@ -77,7 +77,7 @@
                         :data-algolia-lvl="
                           $page.path.startsWith(item__2.path) ? '3' : ''
                         "
-                        >{{ item__2.title }}</span
+                        >{{ item__2.title.split("|")[0] }}</span
                       >
                     </div>
                     <router-link
@@ -90,7 +90,7 @@
                         :data-algolia-lvl="
                           $page.path.startsWith(item__2.path) ? '3' : ''
                         "
-                        >{{ item__2.title }}</a
+                        >{{ item__2.title.split("|")[0] }}</a
                       >
                     </router-link>
                   </div>
@@ -117,7 +117,7 @@
                         @click.native="$emit('closeSidebar')"
                       >
                         <a class="no_arrow" data-algolia-lvl="4">{{
-                          item__3.title
+                          item__3.title.split("|")[0]
                         }}</a>
                       </router-link>
                     </li>
@@ -131,7 +131,7 @@
                           'md-nav__item--code': item__3.frontmatter.code
                         }"
                       >
-                        <a class="no_arrow">{{ item__3.title }}</a>
+                        <a class="no_arrow">{{ item__3.title.split("|")[0] }}</a>
                       </router-link>
                     </li>
                   </div>


### PR DESCRIPTION
## Fixing title names in the sidebar of the doc 

Titles have been modified to respect another format using | as separators. This caused the sidebar (which use the pages title) to get messy with very big title. To fix when rendering the {{item.title}} i split the string and get the 0 element with is the original name 

### To test this feature

Step 1: push and merge
Step 2: check on the documentation sidebar if the titles are right  

