### PR TITLE
Adding : canonicals 

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -251,7 +251,11 @@ module.exports = {
         href: '/favicon/apple-touch-icon-152x152.png',
         sizes: '152x152'
       }
-    ]
+    ],
+    ['link', { rel: 'canonical', href: 'https://next-docs.kuzzle.io/core/2/' }],
+    ['link', { rel: 'canonical', href: 'https://next-docs.kuzzle.io/sdk/js/7/' }],
+    ['link', { rel: 'canonical', href: 'https://next-docs.kuzzle.io/sdk/jvm/1/' }],
+
   ],
   markdown: {
     anchor: {


### PR DESCRIPTION
## Adding global canonicals 

The goal here is to redirect to the newests versions when doing a google search

sdk jvm
core/2
sdk/js/7

### Test this

- run another semrush and compare results
- when merging in prod, change the canonicals to docs.kuzzle instead of next-doc