### PR TITLE
Fix : canonicals different for each page

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -253,41 +253,6 @@ module.exports = {
     ],
 
   ],
-  dir: {
-    "/.repos/kuzzle-2/doc/2": {
-      head: [
-        [
-          'link',
-          {
-            rel: 'canonical',
-            href: 'https://next-docs.kuzzle.io/core/2/',
-          },
-        ],
-      ],
-    },
-    "/.repos/sdk-javascript-7/doc/7": {
-      head: [
-        [
-          'link',
-          {
-            rel: 'canonical',
-            href: 'https://next-docs.kuzzle.io/sdk/js/7/',
-          },
-        ],
-      ],
-    },
-    "/.repos/sdk-jvm-1/doc/1": {
-      head: [
-        [
-          'link',
-          {
-            rel: 'canonical',
-            href: 'https://next-docs.kuzzle.io/sdk/jvm/1/',
-          },
-        ],
-      ],
-    },
-  },
 
   markdown: {
     anchor: {
@@ -365,6 +330,7 @@ module.exports = {
           meta: {
             type: Array,
           },
+          
         },
         exclude: [
           '/sdk/js/6/getting-started/vuejs/without-vuex/src/**/*',

--- a/src/.vuepress/helpers.js
+++ b/src/.vuepress/helpers.js
@@ -19,3 +19,11 @@ export const createMetaTag = (property, content) => {
   meta.setAttribute('content', content);
   return meta;
 };
+
+
+export const createCanonical = (url) => {
+  const link = document.createElement('link');
+  link.setAttribute('rel', 'canonical');
+  link.setAttribute('url', url);
+  return link;
+};

--- a/src/.vuepress/meta-tags-plugin/mixin.js
+++ b/src/.vuepress/meta-tags-plugin/mixin.js
@@ -1,9 +1,15 @@
-import { DEFAULT_VERSION, createMetaTag } from '../helpers';
+import { DEFAULT_VERSION, createMetaTag, createCanonical } from '../helpers';
 
 export default {
   mounted() {
     const head = document.head;
 
+    const host = document.location.host; // https://docs-kuzzle-io for example 
+    const sectionPath = document.location.pathname.split("/").slice(0, 4).join('/'); // /core/2/guides/introduction/what-is-kuzzle/ for example
+
+    const url = `${host}${sectionPath}`;
+
+    head.appendChild(createCanonical(url));
     head.appendChild(createMetaTag('article:tag', this.$page.title));
     head.appendChild(createMetaTag('og:title', this.$page.title));
     head.appendChild(createMetaTag('og:url', document.URL));


### PR DESCRIPTION
##  Fixing canonical url for them to be different on each section of the website 


### How should this be manually tested?

  - Step 1 : merge and build
  - Step 2 : check on te preprod repo if the canonical tags are in the head 
  - Step 3 :  run semrush analysis 
  ...
